### PR TITLE
feat(frontend): add Next.js UI with search and import flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__/
 *.pyc
 .env
+
+frontend/node_modules
+frontend/.next

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,26 @@
+# Frontend
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Create `.env.local`:
+
+```
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+NEXT_PUBLIC_FAKE_TASK_POLL=true
+```
+
+## Features
+
+- Suche mit Facetten und Export
+- Detailansicht
+- Mehrdatei-Import mit Upload-Progress
+
+Screenshots:
+
+![Search](docs/search.png)
+![Import](docs/import.png)

--- a/frontend/app/admin/import/page.tsx
+++ b/frontend/app/admin/import/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useState } from 'react';
+import ImportUploader from '@/components/import-uploader';
+import ImportList, { ImportItem } from '@/components/import-list';
+
+export default function ImportPage() {
+  const [label, setLabel] = useState('');
+  const [items, setItems] = useState<ImportItem[]>([]);
+
+  function handleFiles(files: File[]) {
+    const newItems = files.map((file) => ({
+      id: Math.random().toString(36).slice(2),
+      file,
+      name: file.name,
+      size: file.size,
+      status: 'ready' as const,
+      progress: 0
+    }));
+    setItems((prev) => [...prev, ...newItems]);
+  }
+
+  const allDone = items.length > 0 && items.every((i) => i.status === 'done');
+
+  return (
+    <div className="max-w-3xl mx-auto space-y-4">
+      <h1 className="text-2xl font-bold">Import</h1>
+      <div className="space-y-2">
+        <label className="block text-sm font-medium">Label</label>
+        <input
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          className="border px-2 py-1 rounded w-full"
+          placeholder="z.B. Q3_2025"
+        />
+      </div>
+      <ImportUploader onFiles={handleFiles} />
+      <ImportList label={label} items={items} setItems={setItems} />
+      {allDone && <div className="text-green-600">Alle Uploads abgeschlossen</div>}
+    </div>
+  );
+}

--- a/frontend/app/api/health/route.ts
+++ b/frontend/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/frontend/app/company/[source_id]/page.tsx
+++ b/frontend/app/company/[source_id]/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useCompanyDetail } from '@/lib/queries';
+
+export default function CompanyPage({ params }: { params: { source_id: string } }) {
+  const { data, isLoading } = useCompanyDetail(params.source_id);
+
+  if (isLoading) return <div>Loading...</div>;
+  if (!data) return <div>Not found</div>;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">{data.name}</h1>
+      <div>
+        <h2 className="font-medium">Coordinates</h2>
+        <div className="h-48 bg-muted flex items-center justify-center">
+          {data.lat && data.lng ? `${data.lat}, ${data.lng}` : 'No coordinates'}
+        </div>
+      </div>
+      <div>
+        <h2 className="font-medium">Events</h2>
+        <ul className="list-disc pl-5">
+          {data.events?.map((e: any, idx: number) => (
+            <li key={idx}>{e}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,40 @@
+import '../styles/globals.css';
+import type { Metadata } from 'next';
+import SearchBar from '@/components/search-bar';
+import { ToastProvider } from '@/components/toast';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Link from 'next/link';
+import { useState } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Unternehmensdatenbank',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <html lang="en">
+      <body className="min-h-screen flex">
+        <QueryClientProvider client={queryClient}>
+          <ToastProvider>
+            <aside className="w-48 border-r p-4 space-y-2">
+              <div className="font-bold">Menu</div>
+              <nav className="flex flex-col gap-2">
+                <Link href="/search" className="hover:underline">Search</Link>
+                <Link href="/admin/import" className="hover:underline">Import</Link>
+                <Link href="#" className="hover:underline">Settings</Link>
+              </nav>
+            </aside>
+            <div className="flex-1 flex flex-col">
+              <header className="p-4 border-b">
+                <SearchBar />
+              </header>
+              <main className="p-4 flex-1 overflow-auto">{children}</main>
+            </div>
+          </ToastProvider>
+        </QueryClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Page() {
+  redirect('/search');
+}

--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useSearchCompanies } from '@/lib/queries';
+import FiltersPanel from '@/components/filters-panel';
+import ResultsTable from '@/components/results-table';
+import ExportDialog from '@/components/export-dialog';
+
+export default function SearchPage() {
+  const params = useSearchParams();
+  const queryObj = useMemo(() => {
+    const obj: any = {
+      query: params.get('query') ?? undefined,
+      page: Number(params.get('page') ?? '1'),
+      per_page: Number(params.get('per_page') ?? '20'),
+      sort: params.get('sort') ?? undefined,
+      filters: {} as Record<string, string[]>
+    };
+    params.forEach((v, k) => {
+      if (!['query', 'page', 'per_page', 'sort'].includes(k)) {
+        obj.filters[k] = obj.filters[k] ? [...obj.filters[k], v] : [v];
+      }
+    });
+    return obj;
+  }, [params]);
+
+  const { data, isLoading } = useSearchCompanies(queryObj);
+  const [selected, setSelected] = useState<string[]>([]);
+
+  return (
+    <div className="grid md:grid-cols-[250px_1fr] gap-4">
+      <FiltersPanel facets={data?.facets ?? {}} />
+      <div className="space-y-4">
+        {isLoading && <div>Loading...</div>}
+        {data && (
+          <>
+            <ResultsTable data={data.results} selected={selected} onSelectedChange={setSelected} />
+            <div className="flex justify-end">
+              <ExportDialog selectedIds={selected} />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/export-dialog.tsx
+++ b/frontend/components/export-dialog.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useCreateExport } from '@/lib/queries';
+import { toast } from './toast';
+
+export default function ExportDialog({ selectedIds }: { selectedIds: string[] }) {
+  const [open, setOpen] = useState(false);
+  const [format, setFormat] = useState('csv');
+  const [preset, setPreset] = useState('core');
+  const createExport = useCreateExport();
+  const params = useSearchParams();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const body: any = {
+      format,
+      preset,
+      ids: selectedIds.length > 0 ? selectedIds : undefined,
+      filters: Object.fromEntries(params.entries())
+    };
+    try {
+      await createExport.mutateAsync(body);
+      toast.success('Export gestartet');
+      setOpen(false);
+    } catch {
+      // error toast handled globally
+    }
+  }
+
+  return (
+    <>
+      <button className="px-3 py-1 border rounded" onClick={() => setOpen(true)} disabled={createExport.isPending}>
+        Export
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <form onSubmit={onSubmit} className="bg-white p-4 rounded space-y-4 w-80">
+            <h2 className="text-lg font-medium">Export</h2>
+            <div className="space-y-2">
+              <label className="block text-sm">Format</label>
+              <select value={format} onChange={(e) => setFormat(e.target.value)} className="w-full border px-2 py-1 rounded">
+                <option value="csv">CSV</option>
+                <option value="xlsx">XLSX</option>
+                <option value="parquet">Parquet</option>
+              </select>
+            </div>
+            <div className="space-y-2">
+              <label className="block text-sm">Preset</label>
+              <select value={preset} onChange={(e) => setPreset(e.target.value)} className="w-full border px-2 py-1 rounded">
+                <option value="core">Core</option>
+                <option value="sales">Sales</option>
+                <option value="full">Full</option>
+              </select>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button type="button" onClick={() => setOpen(false)} className="px-3 py-1 border rounded">
+                Cancel
+              </button>
+              <button type="submit" className="px-3 py-1 bg-primary text-primary-foreground rounded" disabled={createExport.isPending}>
+                Start
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/filters-panel.tsx
+++ b/frontend/components/filters-panel.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import clsx from 'clsx';
+
+interface Facets {
+  [key: string]: { value: string; count: number }[];
+}
+
+export default function FiltersPanel({ facets }: { facets: Facets }) {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  function toggleFilter(key: string, value: string) {
+    const url = new URL(window.location.href);
+    const current = url.searchParams.getAll(key);
+    if (current.includes(value)) {
+      const next = current.filter((v) => v !== value);
+      url.searchParams.delete(key);
+      next.forEach((v) => url.searchParams.append(key, v));
+    } else {
+      url.searchParams.append(key, value);
+    }
+    url.searchParams.set('page', '1');
+    router.push(url.pathname + '?' + url.searchParams.toString());
+  }
+
+  return (
+    <aside className="space-y-4">
+      {Object.entries(facets).map(([key, buckets]) => (
+        <div key={key}>
+          <h3 className="font-medium mb-2 capitalize">{key}</h3>
+          <div className="flex flex-wrap gap-2">
+            {buckets.map((b) => {
+              const active = params.getAll(key).includes(b.value);
+              return (
+                <button
+                  key={b.value}
+                  onClick={() => toggleFilter(key, b.value)}
+                  className={clsx(
+                    'px-2 py-1 text-sm border rounded',
+                    active && 'bg-primary text-primary-foreground'
+                  )}
+                >
+                  {b.value} ({b.count})
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </aside>
+  );
+}

--- a/frontend/components/import-list.tsx
+++ b/frontend/components/import-list.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useCreateImport } from '@/lib/queries';
+import { env } from '@/lib/env';
+import { api } from '@/lib/api';
+import { sleep, formatBytes } from '@/lib/utils';
+import JobStatusBadge, { JobStatus } from './job-status-badge';
+import { toast } from './toast';
+
+export type ImportItem = {
+  id: string;
+  file: File;
+  name: string;
+  size: number;
+  status: JobStatus;
+  progress: number;
+  taskId?: string;
+  error?: string;
+};
+
+interface Props {
+  label: string;
+  items: ImportItem[];
+  setItems: (items: ImportItem[] | ((items: ImportItem[]) => ImportItem[])) => void;
+}
+
+export default function ImportList({ label, items, setItems }: Props) {
+  const createImport = useCreateImport();
+  const uploadingRef = useRef(false);
+
+  useEffect(() => {
+    async function process() {
+      if (uploadingRef.current) return;
+      const next = items.find((i) => i.status === 'ready');
+      if (!next || !label) return;
+      uploadingRef.current = true;
+      try {
+        setItems((arr) => arr.map((i) => (i.id === next.id ? { ...i, status: 'uploading', progress: 0 } : i)));
+        const res = await createImport.mutateAsync({
+          label,
+          file: next.file,
+          onUploadProgress: (e) => {
+            const prog = e.total ? Math.round((e.loaded / e.total) * 100) : 0;
+            setItems((arr) => arr.map((i) => (i.id === next.id ? { ...i, progress: prog } : i)));
+          }
+        });
+        setItems((arr) => arr.map((i) => (i.id === next.id ? { ...i, status: 'processing', taskId: res.task_id, progress: 100 } : i)));
+        await pollTask(next.id, res.task_id);
+      } catch (e: any) {
+        toast.error(e.message);
+        setItems((arr) => arr.map((i) => (i.id === next.id ? { ...i, status: 'error', error: e.message } : i)));
+      } finally {
+        uploadingRef.current = false;
+        process();
+      }
+    }
+    process();
+  }, [items, label, createImport, setItems]);
+
+  async function pollTask(localId: string, taskId: string) {
+    if (env.fakeTaskPoll) {
+      await sleep(2000);
+      setItems((arr) => arr.map((i) => (i.id === localId ? { ...i, status: 'done' } : i)));
+      return;
+    }
+    for (let i = 0; i < 60; i++) {
+      try {
+        const { data } = await api.get(`/api/tasks/${taskId}`);
+        if (data.state === 'SUCCESS') {
+          setItems((arr) => arr.map((i) => (i.id === localId ? { ...i, status: 'done' } : i)));
+          return;
+        }
+        if (data.state === 'FAILURE') {
+          setItems((arr) => arr.map((i) => (i.id === localId ? { ...i, status: 'error', error: 'Task failed' } : i)));
+          return;
+        }
+      } catch (e: any) {
+        toast.error(e.message);
+      }
+      await sleep(2000);
+    }
+  }
+
+  function retry(id: string) {
+    setItems((arr) => arr.map((i) => (i.id === id ? { ...i, status: 'ready', progress: 0, error: undefined } : i)));
+  }
+
+  function remove(id: string) {
+    setItems((arr) => arr.filter((i) => i.id !== id));
+  }
+
+  return (
+    <div className="mt-4 space-y-2">
+      {items.map((item) => (
+        <div key={item.id} className="p-2 border rounded flex items-center gap-4">
+          <div className="flex-1">
+            <div className="font-medium">{item.name}</div>
+            <div className="text-xs text-muted-foreground">{formatBytes(item.size)}</div>
+            {item.status === 'uploading' && (
+              <div className="w-full bg-secondary h-2 rounded mt-1">
+                <div className="h-2 bg-primary rounded" style={{ width: `${item.progress}%` }} />
+              </div>
+            )}
+          </div>
+          <JobStatusBadge status={item.status} />
+          {item.status === 'ready' && (
+            <button className="px-2 py-1 text-sm border rounded" onClick={() => remove(item.id)}>
+              Remove
+            </button>
+          )}
+          {item.status === 'error' && (
+            <button className="px-2 py-1 text-sm border rounded" onClick={() => retry(item.id)}>
+              Retry
+            </button>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/import-uploader.tsx
+++ b/frontend/components/import-uploader.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+import { readFileHeadAsText, isLikelyNdjson } from '@/lib/utils';
+import { toast } from './toast';
+
+export default function ImportUploader({ onFiles }: { onFiles: (files: File[]) => void }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = useCallback(async (files: FileList | null) => {
+    if (!files) return;
+    const valid: File[] = [];
+    for (const file of Array.from(files)) {
+      if (!file.name.endsWith('.jsonl')) {
+        toast.error(`${file.name} hat keine .jsonl Endung`);
+        continue;
+      }
+      try {
+        const sample = await readFileHeadAsText(file, 1000);
+        if (!isLikelyNdjson(sample)) {
+          toast.error(`${file.name} scheint kein NDJSON zu sein`);
+          continue;
+        }
+      } catch {
+        toast.error(`${file.name} konnte nicht gelesen werden`);
+        continue;
+      }
+      valid.push(file);
+    }
+    if (valid.length) onFiles(valid);
+  }, [onFiles]);
+
+  return (
+    <div
+      className="border-2 border-dashed rounded p-6 text-center cursor-pointer"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => {
+        e.preventDefault();
+        handleFiles(e.dataTransfer.files);
+      }}
+      onClick={() => inputRef.current?.click()}
+    >
+      <p>Drag & Drop JSONL-Dateien oder klicken zum Auswählen</p>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".jsonl"
+        multiple
+        className="hidden"
+        onChange={(e) => handleFiles(e.target.files)}
+      />
+    </div>
+  );
+}

--- a/frontend/components/job-status-badge.tsx
+++ b/frontend/components/job-status-badge.tsx
@@ -1,0 +1,14 @@
+import clsx from 'clsx';
+
+export type JobStatus = 'ready' | 'uploading' | 'processing' | 'done' | 'error';
+
+export default function JobStatusBadge({ status }: { status: JobStatus }) {
+  const map: Record<JobStatus, string> = {
+    ready: 'bg-gray-200 text-gray-800',
+    uploading: 'bg-blue-200 text-blue-800',
+    processing: 'bg-yellow-200 text-yellow-800',
+    done: 'bg-green-200 text-green-800',
+    error: 'bg-red-200 text-red-800'
+  };
+  return <span className={clsx('px-2 py-1 rounded text-xs', map[status])}>{status}</span>;
+}

--- a/frontend/components/results-table.tsx
+++ b/frontend/components/results-table.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+export interface Company {
+  source_id: string;
+  name: string;
+  [key: string]: any;
+}
+
+export default function ResultsTable({
+  data,
+  selected,
+  onSelectedChange
+}: {
+  data: Company[];
+  selected: string[];
+  onSelectedChange: (ids: string[]) => void;
+}) {
+  const allSelected = selected.length === data.length && data.length > 0;
+
+  function toggle(id: string, checked: boolean) {
+    const next = checked ? [...selected, id] : selected.filter((s) => s !== id);
+    onSelectedChange(next);
+  }
+
+  function toggleAll(checked: boolean) {
+    if (checked) onSelectedChange(data.map((d) => d.source_id));
+    else onSelectedChange([]);
+  }
+
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="text-left border-b">
+          <th className="p-2">
+            <input
+              type="checkbox"
+              aria-label="Select all"
+              checked={allSelected}
+              onChange={(e) => toggleAll(e.target.checked)}
+            />
+          </th>
+          <th className="p-2">Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((item) => (
+          <tr key={item.source_id} className="border-b">
+            <td className="p-2">
+              <input
+                type="checkbox"
+                checked={selected.includes(item.source_id)}
+                onChange={(e) => toggle(item.source_id, e.target.checked)}
+              />
+            </td>
+            <td className="p-2">
+              <a href={`/company/${item.source_id}`} className="text-primary hover:underline">
+                {item.name}
+              </a>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/components/search-bar.tsx
+++ b/frontend/components/search-bar.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function SearchBar() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [value, setValue] = useState(params.get('query') ?? '');
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const url = new URL(window.location.href);
+      if (value) url.searchParams.set('query', value);
+      else url.searchParams.delete('query');
+      url.searchParams.set('page', '1');
+      router.push(url.pathname + '?' + url.searchParams.toString());
+    }, 300);
+    return () => clearTimeout(t);
+  }, [value, router]);
+
+  return (
+    <input
+      aria-label="Search companies"
+      className="w-full max-w-lg px-3 py-2 border rounded-md"
+      placeholder="Search companies..."
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+}

--- a/frontend/components/toast.tsx
+++ b/frontend/components/toast.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export type ToastMessage = {
+  id: number;
+  type: 'success' | 'error' | 'info';
+  message: string;
+};
+
+const listeners = new Set<(toast: ToastMessage) => void>();
+
+function emit(toast: ToastMessage) {
+  listeners.forEach((l) => l(toast));
+}
+
+export const toast = {
+  success(message: string) {
+    emit({ id: Date.now() + Math.random(), type: 'success', message });
+  },
+  error(message: string) {
+    emit({ id: Date.now() + Math.random(), type: 'error', message });
+  },
+  info(message: string) {
+    emit({ id: Date.now() + Math.random(), type: 'info', message });
+  }
+};
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<ToastMessage[]>([]);
+
+  useEffect(() => {
+    const handler = (t: ToastMessage) => {
+      setToasts((prev) => [...prev, t]);
+      setTimeout(() => {
+        setToasts((prev) => prev.filter((p) => p.id !== t.id));
+      }, 4000);
+    };
+    listeners.add(handler);
+    return () => {
+      listeners.delete(handler);
+    };
+  }, []);
+
+  return (
+    <>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className={`px-4 py-2 rounded shadow text-sm border bg-white ${
+              t.type === 'error'
+                ? 'border-red-500 text-red-700'
+                : t.type === 'success'
+                ? 'border-green-500 text-green-700'
+                : 'border-gray-300 text-gray-700'
+            }`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,16 @@
+import axios from "axios";
+import { env } from "./env";
+import { toast } from "@/components/toast";
+
+export const api = axios.create({
+  baseURL: env.apiBaseUrl
+});
+
+api.interceptors.response.use(
+  (res) => res,
+  (error) => {
+    const message = error.response?.data?.detail || error.message;
+    toast.error(message || "Unexpected error");
+    return Promise.reject(error);
+  }
+);

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,0 +1,4 @@
+export const env = {
+  apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || "",
+  fakeTaskPoll: process.env.NEXT_PUBLIC_FAKE_TASK_POLL === "true"
+};

--- a/frontend/lib/queries.ts
+++ b/frontend/lib/queries.ts
@@ -1,0 +1,64 @@
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { api } from "./api";
+import { env } from "./env";
+import { SearchRequest, SearchResponse, ImportResponse } from "./schemas";
+import { sleep } from "./utils";
+
+export function useSearchCompanies(params: SearchRequest) {
+  return useQuery<SearchResponse>({
+    queryKey: ["search", params],
+    queryFn: async () => {
+      const { data } = await api.post<SearchResponse>("/api/search/companies", params);
+      return data;
+    },
+    keepPreviousData: true
+  });
+}
+
+export function useCompanyDetail(id: string) {
+  return useQuery({
+    queryKey: ["company", id],
+    enabled: !!id,
+    queryFn: async () => {
+      const { data } = await api.get(`/api/companies/${id}`);
+      return data;
+    }
+  });
+}
+
+export function useCreateExport() {
+  return useMutation({
+    mutationFn: async (body: any) => {
+      const { data } = await api.post("/api/exports", body);
+      return data;
+    }
+  });
+}
+
+export function useCreateImport() {
+  return useMutation({
+    mutationFn: async ({ label, file, onUploadProgress }: { label: string; file: File; onUploadProgress?: (e: ProgressEvent) => void; }) => {
+      const form = new FormData();
+      form.append("label", label);
+      form.append("file", file);
+      const { data } = await api.post<ImportResponse>("/api/imports", form, { onUploadProgress });
+      return data;
+    }
+  });
+}
+
+export function useTaskPoller(taskId?: string) {
+  return useQuery<{ state: string }>({
+    queryKey: ["task", taskId],
+    enabled: !!taskId,
+    queryFn: async () => {
+      if (env.fakeTaskPoll) {
+        await sleep(2000);
+        return { state: "SUCCESS" };
+      }
+      const { data } = await api.get(`/api/tasks/${taskId}`);
+      return data;
+    },
+    refetchInterval: 2000
+  });
+}

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const SearchRequestSchema = z.object({
+  query: z.string().optional(),
+  page: z.number().int().min(1).default(1),
+  per_page: z.number().int().min(1).max(100).default(20),
+  sort: z.string().optional(),
+  filters: z.record(z.string(), z.array(z.string())).optional()
+});
+export type SearchRequest = z.infer<typeof SearchRequestSchema>;
+
+export const CompanySchema = z.object({
+  source_id: z.string(),
+  name: z.string(),
+  lat: z.number().optional(),
+  lng: z.number().optional(),
+  events: z.array(z.string()).optional()
+});
+
+export const SearchResponseSchema = z.object({
+  results: z.array(CompanySchema),
+  total: z.number(),
+  facets: z.record(z.string(), z.array(z.object({
+    value: z.string(),
+    count: z.number()
+  }))).optional()
+});
+export type SearchResponse = z.infer<typeof SearchResponseSchema>;
+
+export const ExportRequestSchema = z.object({
+  format: z.enum(["csv", "xlsx", "parquet"]),
+  preset: z.enum(["core", "sales", "full"]),
+  columns: z.array(z.string()).optional(),
+  ids: z.array(z.string()).optional(),
+  filters: z.any().optional()
+});
+export type ExportRequest = z.infer<typeof ExportRequestSchema>;
+
+export const ImportResponseSchema = z.object({
+  import_label: z.string(),
+  s3_key: z.string(),
+  task_id: z.string()
+});
+export type ImportResponse = z.infer<typeof ImportResponseSchema>;

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,33 @@
+export function formatBytes(bytes: number, decimals = 1) {
+  if (bytes === 0) return "0 B";
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
+}
+
+export const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+export async function readFileHeadAsText(file: File, bytes = 1024) {
+  return await new Promise<string>((resolve, reject) => {
+    const slice = file.slice(0, bytes);
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = reject;
+    reader.readAsText(slice);
+  });
+}
+
+export function isLikelyNdjson(sample: string, lines = 3) {
+  const arr = sample.split("\n").slice(0, lines);
+  return arr.every((line) => {
+    if (!line.trim()) return true;
+    try {
+      JSON.parse(line);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^4.36.1",
+    "axios": "^1.6.2",
+    "clsx": "^2.0.0",
+    "lucide-react": "^0.292.0",
+    "next": "^14.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4",
+    "zustand": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.5",
+    "@types/react": "^18.2.19",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.51.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.3"
+  }
+}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/shadcn-components.json
+++ b/frontend/shadcn-components.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "rsc": true,
+  "components": []
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 0 0% 100%;
+  --foreground: 222.2 47.4% 11.2%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 47.4% 11.2%;
+  --radius: 0.5rem;
+}
+
+.dark {
+  --background: 222.2 47.4% 11.2%;
+  --foreground: 210 40% 98%;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,71 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))"
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))"
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        }
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)"
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" }
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" }
+        }
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out"
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 frontend with Tailwind and shadcn setup
- implement search, company detail, export and multi-file import UIs with API hooks
- add toast system and Axios instance with error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c1696af2d08323aa367ac66f86698b