### PR TITLE
fix: wrap layout with client providers

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,39 +1,33 @@
 import '../styles/globals.css';
 import type { Metadata } from 'next';
 import SearchBar from '@/components/search-bar';
-import { ToastProvider } from '@/components/toast';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Link from 'next/link';
-import { useState } from 'react';
+import { Providers } from './providers';
 
 export const metadata: Metadata = {
   title: 'Unternehmensdatenbank',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
-
   return (
     <html lang="en">
       <body className="min-h-screen flex">
-        <QueryClientProvider client={queryClient}>
-          <ToastProvider>
-            <aside className="w-48 border-r p-4 space-y-2">
-              <div className="font-bold">Menu</div>
-              <nav className="flex flex-col gap-2">
-                <Link href="/search" className="hover:underline">Search</Link>
-                <Link href="/admin/import" className="hover:underline">Import</Link>
-                <Link href="#" className="hover:underline">Settings</Link>
-              </nav>
-            </aside>
-            <div className="flex-1 flex flex-col">
-              <header className="p-4 border-b">
-                <SearchBar />
-              </header>
-              <main className="p-4 flex-1 overflow-auto">{children}</main>
-            </div>
-          </ToastProvider>
-        </QueryClientProvider>
+        <Providers>
+          <aside className="w-48 border-r p-4 space-y-2">
+            <div className="font-bold">Menu</div>
+            <nav className="flex flex-col gap-2">
+              <Link href="/search" className="hover:underline">Search</Link>
+              <Link href="/admin/import" className="hover:underline">Import</Link>
+              <Link href="#" className="hover:underline">Settings</Link>
+            </nav>
+          </aside>
+          <div className="flex-1 flex flex-col">
+            <header className="p-4 border-b">
+              <SearchBar />
+            </header>
+            <main className="p-4 flex-1 overflow-auto">{children}</main>
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '@/components/toast';
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- wrap server layout with client-side provider component for React Query and toasts

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*
- `pytest -q` *(fails: httpx missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c18ccf95708323a529d3db3a24dc4a