### PR TITLE
Parse NorthData export structure

### DIFF
--- a/backend/app/schemas/company.py
+++ b/backend/app/schemas/company.py
@@ -13,6 +13,21 @@ class Event(BaseModel):
 class Company(BaseModel):
     source_id: str
     raw_name: Optional[str] = None
+    legal_form: Optional[str] = None
+    name: Optional[str] = None
+    street: Optional[str] = None
+    postal_code: Optional[str] = None
+    city: Optional[str] = None
+    state: Optional[str] = None
+    country: Optional[str] = None
+    lat: Optional[float] = None
+    lng: Optional[float] = None
+    register_id: Optional[str] = None
+    register_city: Optional[str] = None
+    register_country: Optional[str] = None
+    register_unique_key: Optional[str] = None
+    status: Optional[str] = None
+    terminated: Optional[bool] = None
 
 
 class CompanyDetailResponse(BaseModel):

--- a/backend/app/utils/staging_loader.py
+++ b/backend/app/utils/staging_loader.py
@@ -1,2 +1,53 @@
-def load_to_staging(rows: list[dict]) -> None:
-    pass
+"""Helpers for persisting parsed import data into staging tables."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+from sqlalchemy import text
+
+
+def load_to_staging(rows: List[Dict]) -> None:
+    """Insert parsed rows into the ``staging_*`` tables.
+
+    Each row is expected to contain ``company`` and ``events`` keys. The
+    function uses a direct SQL approach to avoid ORM overhead.
+    """
+
+    if not rows:
+        return
+
+    from ..db import engine
+
+    with engine.begin() as conn:
+        for row in rows:
+            company = row["company"]
+            conn.execute(
+                text(
+                    "INSERT INTO staging_companies (source_id, data, run_id) "
+                    "VALUES (:source_id, :data, :run_id)"
+                ),
+                {
+                    "source_id": company["source_id"],
+                    "data": json.dumps(company),
+                    "run_id": 0,
+                },
+            )
+
+            for event in row["events"]:
+                conn.execute(
+                    text(
+                        "INSERT INTO staging_events "
+                        "(source_id, event_date, event_type, description, run_id) "
+                        "VALUES (:source_id, :event_date, :event_type, "
+                        ":description, :run_id)"
+                    ),
+                    {
+                        "source_id": company["source_id"],
+                        "event_date": event.get("event_date"),
+                        "event_type": event.get("event_type"),
+                        "description": event.get("description"),
+                        "run_id": 0,
+                    },
+                )

--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -1,6 +1,57 @@
+import json
+
 from .celery_app import celery_app
+from ..schemas.company import Company, Event
+from ..utils.staging_loader import load_to_staging
 
 
 @celery_app.task
 def run_import(s3_key: str) -> str:
+    """Import companies from an NDJSON file.
+
+    The ``s3_key`` parameter is treated as a local file path. Each line is
+    parsed according to the NorthData export structure and relevant fields are
+    written into the staging tables.
+    """
+
+    rows: list[dict] = []
+    with open(s3_key, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            data = json.loads(line)
+
+            company = Company(
+                source_id=data["id"],
+                raw_name=data.get("rawName"),
+                legal_form=data.get("name", {}).get("legalForm"),
+                name=data.get("name", {}).get("name"),
+                street=data.get("address", {}).get("street"),
+                postal_code=data.get("address", {}).get("postalCode"),
+                city=data.get("address", {}).get("city"),
+                state=data.get("address", {}).get("state"),
+                country=data.get("address", {}).get("country"),
+                lat=data.get("address", {}).get("lat"),
+                lng=data.get("address", {}).get("lng"),
+                register_id=data.get("register", {}).get("id"),
+                register_city=data.get("register", {}).get("city"),
+                register_country=data.get("register", {}).get("country"),
+                register_unique_key=data.get("register", {}).get("uniqueKey"),
+                status=data.get("status"),
+                terminated=data.get("terminated"),
+            )
+
+            events = [
+                Event(
+                    event_date=item.get("date"),
+                    event_type=item.get("type"),
+                    description=item.get("description"),
+                ).model_dump()
+                for item in data.get("events", {}).get("items", [])
+            ]
+
+            rows.append({"company": company.model_dump(), "events": events})
+
+    load_to_staging(rows)
     return s3_key


### PR DESCRIPTION
## Summary
- parse NDJSON import files in the new NorthData schema
- extend Company schema with address, register and status fields
- load imported companies and events into staging tables

## Testing
- `ruff check backend`
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_b_68c18f8d40708323a3f2b031111753a1