### PR TITLE
Handle large NDJSON uploads by reading bigger sample and ignoring truncated lines

### DIFF
--- a/frontend/components/import-uploader.tsx
+++ b/frontend/components/import-uploader.tsx
@@ -16,7 +16,7 @@ export default function ImportUploader({ onFiles }: { onFiles: (files: File[]) =
         continue;
       }
       try {
-        const sample = await readFileHeadAsText(file, 1000);
+        const sample = await readFileHeadAsText(file, 64 * 1024);
         if (!isLikelyNdjson(sample)) {
           toast.error(`${file.name} scheint kein NDJSON zu sein`);
           continue;

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -20,7 +20,9 @@ export async function readFileHeadAsText(file: File, bytes = 1024) {
 }
 
 export function isLikelyNdjson(sample: string, lines = 3) {
-  const arr = sample.split("\n").slice(0, lines);
+  let arr = sample.split("\n");
+  if (!sample.endsWith("\n")) arr.pop();
+  arr = arr.slice(0, lines);
   return arr.every((line) => {
     if (!line.trim()) return true;
     try {


### PR DESCRIPTION
## Summary
- expand initial file read when validating uploads to 64KB
- ignore incomplete last line when checking NDJSON samples

## Testing
- `node - <<'NODE' ... NODE`
- `npm run lint` *(fails: prompts for ESLint config)*
- `pytest` *(fails: httpx not installed; pip install httpx failed with 403)*

------
https://chatgpt.com/codex/tasks/task_b_68c1948aeb1c83239f1854a233e49e50