### PR TITLE
feat: validate API base URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ This project provides an API for managing company data in Germany.
 
 4. Frontend starten (optional):
 
-   ```bash
-   cd frontend
-   npm install
-   npm run dev
-   ```
+   Das Frontend ben\u00f6tigt die Umgebungsvariable `NEXT_PUBLIC_API_BASE_URL`, die auf die Basis-URL des Backends zeigt.
+
+    ```bash
+    cd frontend
+    npm install
+    echo "NEXT_PUBLIC_API_BASE_URL=http://localhost:8080" > .env.local
+    npm run dev
+    ```
 
 Die API ist anschlie\u00dfend unter <http://localhost:8080> erreichbar und die Weboberfl\u00e4che unter <http://localhost:3000>.
 
@@ -82,11 +85,14 @@ Die API ist anschlie\u00dfend unter <http://localhost:8080> erreichbar und die W
 
 6. Frontend starten (optional):
 
-   ```bash
-   cd frontend
-   npm install
-   npm run dev
-   ```
+   Das Frontend ben\u00f6tigt die Umgebungsvariable `NEXT_PUBLIC_API_BASE_URL`, die auf die Basis-URL des Backends zeigt.
+
+    ```bash
+    cd frontend
+    npm install
+    echo "NEXT_PUBLIC_API_BASE_URL=http://localhost:8080" > .env.local
+    npm run dev
+    ```
 
 Die API ist anschließend unter <http://localhost:8080> erreichbar und die Weboberfläche unter <http://localhost:3000>.
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,8 +2,10 @@ import axios from "axios";
 import { env } from "./env";
 import { toast } from "@/components/toast";
 
+const baseURL = env.apiBaseUrl || "http://localhost:8000";
+
 export const api = axios.create({
-  baseURL: env.apiBaseUrl
+  baseURL,
 });
 
 api.interceptors.response.use(

--- a/frontend/lib/env.ts
+++ b/frontend/lib/env.ts
@@ -1,4 +1,12 @@
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+if (!apiBaseUrl) {
+  throw new Error(
+    "NEXT_PUBLIC_API_BASE_URL ist nicht gesetzt. Bitte die Variable in .env.local definieren."
+  );
+}
+
 export const env = {
-  apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || "",
-  fakeTaskPoll: process.env.NEXT_PUBLIC_FAKE_TASK_POLL === "true"
+  apiBaseUrl,
+  fakeTaskPoll: process.env.NEXT_PUBLIC_FAKE_TASK_POLL === "true",
 };


### PR DESCRIPTION
## Summary
- fail fast when NEXT_PUBLIC_API_BASE_URL is missing
- default API base URL to http://localhost:8000
- document required NEXT_PUBLIC_API_BASE_URL in README

## Testing
- `CI=true npm run lint` *(fails: prompts for ESLint setup)*
- `pytest -q` *(fails: httpx missing)*
- `pip install httpx` *(fails: Could not find a version that satisfies the requirement httpx)*

------
https://chatgpt.com/codex/tasks/task_b_68c275b513dc8323aca9a240847c0c30