### PR TITLE
Add python-multipart to backend dependencies

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ python-dotenv
 pandas
 openpyxl
 pydantic-settings
+python-multipart


### PR DESCRIPTION
## Summary
- add python-multipart requirement for backend

## Testing
- `pytest`
- `ruff check .`
- `docker compose build backend` *(fails: command not found)*
- `curl http://localhost:8080/api/imports` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_b_68c2d7dcec2c8323bec60edc90353f61