### PR TITLE
Enable configurable CORS middleware

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -19,6 +19,9 @@ class Settings(BaseSettings):
     s3_secret_key: str = "minio123"
     s3_bucket: str = "companies"
 
+    # Origins allowed for CORS
+    allowed_origins: list[str] = ["http://localhost:3000"]
+
     class Config:
         env_file = ".env"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,24 @@
 from fastapi import Depends, FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from opensearchpy import OpenSearch
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
+from .config import get_settings
 from .deps import get_db_conn, get_os_client
 from .routers import companies, exports, imports, salesforce, search
 
 app = FastAPI(title="BVMW Companies API")
+
+settings = get_settings()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(search.router)
 app.include_router(companies.router)


### PR DESCRIPTION
## Summary
- import and configure CORSMiddleware for FastAPI
- centralize allowed origins in settings

## Testing
- `ruff check backend/app/main.py backend/app/config.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c2dc06fc0483239607d36a3c3afaa2