### PR TITLE
Register imports endpoint at root and return task IDs

### DIFF
--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -1,13 +1,15 @@
 from fastapi import APIRouter, Form, UploadFile
+from uuid import uuid4
 
 from ..schemas.import_ import ImportResponse
 
 router = APIRouter(prefix="/api/imports", tags=["imports"])
 
 
-@router.post("", response_model=ImportResponse)
+@router.post("/", response_model=ImportResponse)
 async def create_import(
     label: str = Form(...), file: UploadFile | None = None
 ) -> ImportResponse:
     filename = file.filename if file else ""
-    return ImportResponse(import_label=label, s3_key=filename, task_id="dummy")
+    task_id = uuid4().hex
+    return ImportResponse(import_label=label, s3_key=filename, task_id=task_id)


### PR DESCRIPTION
## Summary
- Register `/api/imports` POST route explicitly at `"/"`
- Return a generated task ID for imports using `uuid4`

## Testing
- `pytest`
- `docker compose build backend` *(fails: command not found)*
- `docker compose up -d backend` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c2e2b1ed508323b1375d55708cd142