### PR TITLE
Remove trailing slash from imports endpoint

### DIFF
--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -6,7 +6,7 @@ from ..schemas.import_ import ImportResponse
 router = APIRouter(prefix="/api/imports", tags=["imports"])
 
 
-@router.post("/", response_model=ImportResponse)
+@router.post("", response_model=ImportResponse)
 async def create_import(
     label: str = Form(...), file: UploadFile | None = None
 ) -> ImportResponse:


### PR DESCRIPTION
## Summary
- expose imports endpoint at `/api/imports` by removing trailing slash

## Testing
- `ruff check backend/app/routers/imports.py`
- `black backend/app/routers/imports.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c2e6d698f88323a35da7ef830277e4