### PR TITLE
Implement OpenSearch query for company search

### DIFF
--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -1,11 +1,79 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from opensearchpy import OpenSearch
 
 
-def search_companies(client: OpenSearch, query: Dict[str, Any]) -> Dict[str, Any]:
-    """Search companies in OpenSearch.
+INDEX = "companies"
 
-    Currently returns an empty result set as a placeholder implementation.
-    """
-    return {"total": 0, "results": [], "facets": {}}
+
+def _build_query(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the OpenSearch query body from API parameters."""
+
+    page = max(params.get("page", 1), 1)
+    per_page = params.get("per_page", 20)
+
+    body: Dict[str, Any] = {
+        "from": (page - 1) * per_page,
+        "size": per_page,
+        "query": {"match_all": {}},
+        "aggs": {
+            "state": {"terms": {"field": "state.keyword"}},
+            "city": {"terms": {"field": "city.keyword"}},
+            "status": {"terms": {"field": "status.keyword"}},
+            "legal_form": {"terms": {"field": "legal_form.keyword"}},
+        },
+    }
+
+    filters: List[Dict[str, Any]] = []
+
+    if q := params.get("query"):
+        body["query"] = {"simple_query_string": {"query": q}}
+
+    for field in ["state", "city", "postal_code", "wz", "status", "legal_form"]:
+        if value := params.get(field):
+            filters.append({"term": {f"{field}.keyword": value}})
+
+    if (
+        params.get("lat") is not None
+        and params.get("lng") is not None
+        and params.get("radius_km")
+    ):
+        filters.append(
+            {
+                "geo_distance": {
+                    "distance": f"{params['radius_km']}km",
+                    "location": {"lat": params["lat"], "lon": params["lng"]},
+                }
+            }
+        )
+
+    if filters:
+        body["query"] = {"bool": {"must": body["query"], "filter": filters}}
+
+    if sort := params.get("sort"):
+        body["sort"] = [sort]
+
+    return body
+
+
+def search_companies(client: OpenSearch, query: Dict[str, Any]) -> Dict[str, Any]:
+    """Search companies in OpenSearch and return a structured result."""
+
+    body = _build_query(query)
+    response = client.search(index=INDEX, body=body)
+
+    hits = response.get("hits", {})
+    total = hits.get("total", {}).get("value", 0)
+    results = [
+        {
+            "source_id": h.get("_source", {}).get("source_id", ""),
+            "name": h.get("_source", {}).get("name"),
+        }
+        for h in hits.get("hits", [])
+    ]
+
+    facets: Dict[str, Dict[str, int]] = {}
+    for facet, agg in response.get("aggregations", {}).items():
+        facets[facet] = {bucket["key"]: bucket["doc_count"] for bucket in agg.get("buckets", [])}
+
+    return {"total": total, "results": results, "facets": facets}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -3,14 +3,37 @@ import pytest
 pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
+from backend.app.deps import get_os_client
 from backend.app.main import app
 
 
+class DummyOSClient:
+    def search(self, index: str, body: dict) -> dict:  # pragma: no cover - simple stub
+        assert index == "companies"
+        return {
+            "hits": {
+                "total": {"value": 2},
+                "hits": [
+                    {"_source": {"source_id": "1", "name": "Foo"}},
+                    {"_source": {"source_id": "2", "name": "Bar"}},
+                ],
+            },
+            "aggregations": {
+                "status": {"buckets": [{"key": "active", "doc_count": 2}]}
+            },
+        }
+
+
 def test_search_companies() -> None:
+    app.dependency_overrides[get_os_client] = lambda: DummyOSClient()
     client = TestClient(app)
     response = client.post("/api/search/companies", json={"query": "foo"})
     assert response.status_code == 200
     data = response.json()
-    assert data["total"] == 0
-    assert data["results"] == []
-    assert "facets" in data
+    assert data["total"] == 2
+    assert data["results"] == [
+        {"source_id": "1", "name": "Foo"},
+        {"source_id": "2", "name": "Bar"},
+    ]
+    assert data["facets"]["status"]["active"] == 2
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- build OpenSearch query with filters, pagination, and facets to return company search results
- test API search endpoint using a dummy OpenSearch client

## Testing
- `pip install httpx -q` (failed: Could not connect to proxy)
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c2ec113efc8323a9916aaf030325f9