### PR TITLE
docs: explain OpenSearch SSL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ OPENSEARCH_HOST=opensearch
 OPENSEARCH_PORT=9200
 OPENSEARCH_USER=admin
 OPENSEARCH_PASSWORD=admin
+# Enable HTTPS for OpenSearch.
+# Certificate verification is disabled by default, so self-signed
+# certificates are accepted. Use a trusted certificate in production.
 OPENSEARCH_USE_SSL=true
 S3_ENDPOINT_URL=http://minio:9000
 S3_ACCESS_KEY=minio

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ docker compose up --build
 Swagger UI: <http://localhost:8080/docs>
 MinIO Console: <http://localhost:9001>
 
+### OpenSearch über HTTPS
+
+Setze in deiner `.env` die Variable `OPENSEARCH_USE_SSL=true`, wenn dein OpenSearch-Cluster über HTTPS erreichbar ist.
+Die Anwendung prüft Zertifikate dabei nicht (`verify_certs=False`), sodass selbstsignierte Zertifikate akzeptiert werden.
+Für produktive Umgebungen sollte ein vertrauenswürdiges Zertifikat genutzt und die Prüfung aktiviert werden.
+
 ### Example Requests
 
 Import:


### PR DESCRIPTION
## Summary
- document how to enable HTTPS for OpenSearch via `OPENSEARCH_USE_SSL`
- clarify that certificate verification is disabled and self-signed certs are accepted
- comment SSL option in `.env.example`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c2f3933fe8832387ce93746dc6af5b