### PR TITLE
Disable OpenSearch security and remove credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,8 @@ REDIS_HOST=redis
 REDIS_PORT=6379
 OPENSEARCH_HOST=opensearch
 OPENSEARCH_PORT=9200
-OPENSEARCH_USER=admin
-OPENSEARCH_PASSWORD=admin
-# Enable HTTPS for OpenSearch.
-# Certificate verification is disabled by default, so self-signed
-# certificates are accepted. Use a trusted certificate in production.
-OPENSEARCH_USE_SSL=true
+# Set to true if your OpenSearch cluster uses HTTPS.
+OPENSEARCH_USE_SSL=false
 S3_ENDPOINT_URL=http://minio:9000
 S3_ACCESS_KEY=minio
 S3_SECRET_KEY=minio123

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,8 +13,6 @@ class Settings(BaseSettings):
 
     opensearch_host: str = "opensearch"
     opensearch_port: int = 9200
-    opensearch_user: str = "admin"
-    opensearch_password: str = "admin"
     opensearch_use_ssl: bool = False
 
     s3_endpoint_url: str = "http://minio:9000"

--- a/backend/app/opensearch_client.py
+++ b/backend/app/opensearch_client.py
@@ -18,5 +18,4 @@ def get_opensearch() -> OpenSearch:
         http_compress=True,
         use_ssl=settings.opensearch_use_ssl,
         verify_certs=False,
-        basic_auth=(settings.opensearch_user, settings.opensearch_password),
     )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,13 +27,9 @@ services:
     environment:
       - discovery.type=single-node
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
-      - plugins.security.ssl.http.enabled=true
-      - plugins.security.ssl.http.pemcert_filepath=certs/opensearch.crt
-      - plugins.security.ssl.http.pemkey_filepath=certs/opensearch.key
+      - plugins.security.disabled=true
     ports:
       - "9200:9200"
-    volumes:
-      - ./opensearch/certs:/usr/share/opensearch/config/certs
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
## Summary
- disable OpenSearch security plugin in docker-compose
- drop OpenSearch username/password settings and auth usage
- update example env for unsecured OpenSearch

## Testing
- `black backend/app/config.py backend/app/opensearch_client.py`
- `ruff check backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c3e019b7ec8323b81f22ad562e824f