### PR TITLE
Ensure companies index exists at startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from sqlalchemy.engine import Connection
 
 from .config import get_settings
 from .deps import get_db_conn, get_os_client
+from .opensearch_client import ensure_companies_index, get_opensearch
 from .routers import companies, exports, imports, salesforce, search, tasks
 
 app = FastAPI(title="BVMW Companies API")
@@ -26,6 +27,12 @@ app.include_router(imports.router)
 app.include_router(exports.router)
 app.include_router(salesforce.router)
 app.include_router(tasks.router)
+
+
+@app.on_event("startup")
+def startup_event() -> None:
+    client = get_opensearch()
+    ensure_companies_index(client)
 
 
 @app.get("/healthz")

--- a/backend/app/opensearch_client.py
+++ b/backend/app/opensearch_client.py
@@ -19,3 +19,25 @@ def get_opensearch() -> OpenSearch:
         use_ssl=settings.opensearch_use_ssl,
         verify_certs=False,
     )
+
+
+def ensure_companies_index(client: OpenSearch) -> None:
+    """Ensure that the ``companies`` index exists with the proper mappings."""
+    if not client.indices.exists("companies"):
+        client.indices.create(
+            "companies",
+            body={
+                "mappings": {
+                    "properties": {
+                        "source_id": {"type": "keyword"},
+                        "name": {"type": "text"},
+                        "state": {"type": "keyword"},
+                        "city": {"type": "keyword"},
+                        "postal_code": {"type": "keyword"},
+                        "status": {"type": "keyword"},
+                        "legal_form": {"type": "keyword"},
+                        "location": {"type": "geo_point"},
+                    }
+                }
+            },
+        )


### PR DESCRIPTION
## Summary
- ensure `companies` index exists with mapping
- call index setup in FastAPI startup hook

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c3e8cf9c38832388da8139a8359add