### PR TITLE
Add tests for missing OpenSearch index scenarios

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -52,3 +52,12 @@ def test_search_companies_index_missing() -> None:
     assert response.status_code == 404
     assert response.json() == {"detail": "index not found"}
     app.dependency_overrides.clear()
+
+
+def test_search_companies_no_internal_server_error() -> None:
+    """Ensure missing index does not cause a 500 error."""
+    app.dependency_overrides[get_os_client] = lambda: DummyMissingIndexClient()
+    client = TestClient(app)
+    response = client.post("/api/search/companies", json={"query": "foo"})
+    assert response.status_code != 500
+    app.dependency_overrides.clear()

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -1,0 +1,31 @@
+import pytest
+
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+import backend.app.main as main
+from backend.app.main import app
+
+
+class DummyIndices:
+    def __init__(self) -> None:
+        self._exists = False
+
+    def exists(self, name: str) -> bool:  # pragma: no cover - simple stub
+        return self._exists
+
+    def create(self, name: str, body: dict) -> None:  # pragma: no cover - simple stub
+        self._exists = True
+
+
+class DummyOSClient:
+    def __init__(self) -> None:
+        self.indices = DummyIndices()
+
+
+def test_startup_creates_companies_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    dummy = DummyOSClient()
+    monkeypatch.setattr(main, "get_opensearch", lambda: dummy)
+    with TestClient(app):
+        pass
+    assert dummy.indices.exists("companies")


### PR DESCRIPTION
## Summary
- add regression test ensuring search endpoint doesn't return 500 when index is missing
- add integration test confirming companies index exists after startup

## Testing
- `pytest` *(fails: no, but skipped due to missing httpx)*

------
https://chatgpt.com/codex/tasks/task_b_68c3ea2b862083239c49138154e1a6ee