### PR TITLE
Use keyword arguments for OpenSearch index operations

### DIFF
--- a/backend/app/opensearch_client.py
+++ b/backend/app/opensearch_client.py
@@ -23,9 +23,9 @@ def get_opensearch() -> OpenSearch:
 
 def ensure_companies_index(client: OpenSearch) -> None:
     """Ensure that the ``companies`` index exists with the proper mappings."""
-    if not client.indices.exists("companies"):
+    if not client.indices.exists(index="companies"):
         client.indices.create(
-            "companies",
+            index="companies",
             body={
                 "mappings": {
                     "properties": {

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -11,10 +11,10 @@ class DummyIndices:
     def __init__(self) -> None:
         self._exists = False
 
-    def exists(self, name: str) -> bool:  # pragma: no cover - simple stub
+    def exists(self, index: str) -> bool:  # pragma: no cover - simple stub
         return self._exists
 
-    def create(self, name: str, body: dict) -> None:  # pragma: no cover - simple stub
+    def create(self, index: str, body: dict) -> None:  # pragma: no cover - simple stub
         self._exists = True
 
 
@@ -28,4 +28,4 @@ def test_startup_creates_companies_index(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(main, "get_opensearch", lambda: dummy)
     with TestClient(app):
         pass
-    assert dummy.indices.exists("companies")
+    assert dummy.indices.exists(index="companies")


### PR DESCRIPTION
## Summary
- use `index` keyword when checking and creating OpenSearch indices
- update tests to match keyword-based index operations

## Testing
- `black backend/app/opensearch_client.py tests/test_startup.py`
- `ruff check backend/app/opensearch_client.py tests/test_startup.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c3eca2eab88323bbe82b276e8e3602