### PR TITLE
Return facet buckets as value/count pairs

### DIFF
--- a/backend/app/schemas/search.py
+++ b/backend/app/schemas/search.py
@@ -24,7 +24,12 @@ class CompanyItem(BaseModel):
     name: Optional[str] = None
 
 
+class FacetBucket(BaseModel):
+    value: str
+    count: int
+
+
 class CompanySearchResponse(BaseModel):
     total: int
     results: List[CompanyItem]
-    facets: Dict[str, Dict[str, int]] = Field(default_factory=dict)
+    facets: Dict[str, List[FacetBucket]] = Field(default_factory=dict)

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -76,8 +76,11 @@ def search_companies(client: OpenSearch, query: Dict[str, Any]) -> Dict[str, Any
         for h in hits.get("hits", [])
     ]
 
-    facets: Dict[str, Dict[str, int]] = {}
+    facets: Dict[str, List[Dict[str, Any]]] = {}
     for facet, agg in response.get("aggregations", {}).items():
-        facets[facet] = {bucket["key"]: bucket["doc_count"] for bucket in agg.get("buckets", [])}
+        facets[facet] = [
+            {"value": bucket["key"], "count": bucket["doc_count"]}
+            for bucket in agg.get("buckets", [])
+        ]
 
     return {"total": total, "results": results, "facets": facets}

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -41,7 +41,7 @@ def test_search_companies() -> None:
         {"source_id": "1", "name": "Foo"},
         {"source_id": "2", "name": "Bar"},
     ]
-    assert data["facets"]["status"]["active"] == 2
+    assert data["facets"]["status"][0] == {"value": "active", "count": 2}
     app.dependency_overrides.clear()
 
 


### PR DESCRIPTION
## Summary
- Represent search facets as arrays of `{value, count}` objects
- Add `FacetBucket` schema and update response type
- Adjust search test for new facet structure

## Testing
- `black backend tests`
- `ruff check backend tests`
- `pytest -q` *(fails: 3 skipped; missing httpx dependency)*

------
https://chatgpt.com/codex/tasks/task_b_68c3f97f748c8323931e46716633002d