### PR TITLE
Use PostGIS image and document migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,17 @@ This project provides an API for managing company data in Germany.
    docker compose up --build
    ```
 
-4. Frontend starten (optional):
+   Die Datenbank nutzt ein PostgreSQL-Image mit PostGIS-Erweiterung.
+
+4. SQL-Migrationen ausführen:
+
+   ```bash
+   for f in backend/migrations/*.sql; do
+     docker compose exec -T db psql -U postgres -d companies -f "$f"
+   done
+   ```
+
+5. Frontend starten (optional):
 
    Das Frontend ben\u00f6tigt die Umgebungsvariable `NEXT_PUBLIC_API_BASE_URL`, die auf die Basis-URL des Backends zeigt.
 
@@ -102,6 +112,9 @@ Die API ist anschließend unter <http://localhost:8080> erreichbar und die Webob
 ```bash
 cp .env.example .env
 docker compose up --build
+for f in backend/migrations/*.sql; do
+  docker compose exec -T db psql -U postgres -d companies -f "$f"
+done
 ```
 
 Swagger UI: <http://localhost:8080/docs>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   backend:
     build: ./backend
@@ -11,7 +10,7 @@ services:
       - opensearch
       - minio
   db:
-    image: postgres:16
+    image: postgis/postgis:16-3.4
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}


### PR DESCRIPTION
## Summary
- use a PostGIS-enabled PostgreSQL image in docker compose
- document running SQL migrations after starting services

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c40601dea0832390a129bbaf8a664a