### PR TITLE
Add Celery worker service for imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,16 @@ Für produktive Umgebungen sollte ein vertrauenswürdiges Zertifikat genutzt und
 
 ### Example Requests
 
-Import:
+Import (requires running worker service):
+
+Start the Celery worker before triggering an import:
+
+```bash
+docker compose up worker
+```
+
+Then run the import:
+
 ```bash
 curl -F "label=Q3_2025" -F "file=@/path/to/file.jsonl" http://localhost:8080/api/imports
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,15 @@ services:
       - redis
       - opensearch
       - minio
+  worker:
+    build: ./backend
+    env_file: .env
+    command: celery -A app.workers.celery_app worker -l info
+    depends_on:
+      - db
+      - redis
+      - opensearch
+      - minio
   db:
     image: postgis/postgis:16-3.4
     environment:


### PR DESCRIPTION
## Summary
- add `worker` service to docker-compose for running Celery tasks
- document how to start the worker before running imports

## Testing
- `make test` *(fails: Makefile:2: *** missing separator. Stop.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68c40c693244832390504933a86d93e3