### PR TITLE
Ensure Celery loads task modules

### DIFF
--- a/backend/app/workers/celery_app.py
+++ b/backend/app/workers/celery_app.py
@@ -9,6 +9,11 @@ celery_app = Celery(
     broker=f"redis://{settings.redis_host}:{settings.redis_port}/0",
     backend=f"redis://{settings.redis_host}:{settings.redis_port}/0",
 )
+celery_app.conf.imports = (
+    "app.workers.tasks_import",
+    "app.workers.tasks_export",
+    "app.workers.tasks_reindex",
+)
 
 
 @celery_app.task


### PR DESCRIPTION
## Summary
- load import/export/reindex tasks when starting Celery app

## Testing
- `pytest`
- `ruff check backend/app/workers/celery_app.py`
- `timeout 5 celery -A app.workers.celery_app:celery_app worker --loglevel=INFO` *(fails: Error -2 connecting to redis:6379)*

------
https://chatgpt.com/codex/tasks/task_b_68c421e357e48323b334e60a8bff41c2