### PR TITLE
Index imported companies in OpenSearch

### DIFF
--- a/backend/app/opensearch_client.py
+++ b/backend/app/opensearch_client.py
@@ -1,4 +1,6 @@
-from opensearchpy import OpenSearch
+from typing import Iterable, Mapping, Any
+
+from opensearchpy import OpenSearch, helpers
 
 from .config import get_settings
 
@@ -41,3 +43,30 @@ def ensure_companies_index(client: OpenSearch) -> None:
                 }
             },
         )
+
+
+def index_companies(client: OpenSearch, companies: Iterable[Mapping[str, Any]]) -> None:
+    """Index the given ``companies`` into the ``companies`` OpenSearch index."""
+    actions = []
+    for item in companies:
+        doc = {
+            "_index": "companies",
+            "_id": item["source_id"],
+            "_source": {
+                "source_id": item.get("source_id"),
+                "name": item.get("name"),
+                "state": item.get("state"),
+                "city": item.get("city"),
+                "postal_code": item.get("postal_code"),
+                "status": item.get("status"),
+                "legal_form": item.get("legal_form"),
+            },
+        }
+        lat = item.get("lat")
+        lng = item.get("lng")
+        if lat is not None and lng is not None:
+            doc["_source"]["location"] = {"lat": lat, "lon": lng}
+        actions.append(doc)
+
+    if actions:
+        helpers.bulk(client, actions)


### PR DESCRIPTION
## Summary
- index companies into OpenSearch after promoting import data
- add `index_companies` helper to bulk index documents

## Testing
- `black backend`
- `ruff check backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c42567b9e08323a4fe4e7958a0b5c1