### PR TITLE
Add script for OpenSearch reindexing

### DIFF
--- a/backend/scripts/reindex_companies.py
+++ b/backend/scripts/reindex_companies.py
@@ -1,0 +1,36 @@
+from sqlalchemy import text
+
+from backend.app.db import engine
+from backend.app.opensearch_client import (
+    ensure_companies_index,
+    get_opensearch,
+    index_companies,
+)
+
+
+QUERY = """
+    SELECT
+        source_id,
+        name_norm AS name,
+        state,
+        city,
+        postal_code,
+        status,
+        legal_form,
+        lat,
+        lng
+    FROM companies
+"""
+
+
+def main() -> None:
+    with engine.begin() as conn:
+        companies = conn.execute(text(QUERY)).mappings().all()
+
+    client = get_opensearch()
+    ensure_companies_index(client)
+    index_companies(client, companies)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add standalone script to read all companies from the database and bulk index into OpenSearch

## Testing
- `black backend/scripts/reindex_companies.py`
- `ruff check backend` *(fails: E501 Line too long in backend/app/routers/companies.py)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c428489e3083239b91171e7ececf2e