### PR TITLE
Show address, industry, and persons on company details

### DIFF
--- a/frontend/app/company/[source_id]/page.tsx
+++ b/frontend/app/company/[source_id]/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useCompanyDetail } from '@/lib/queries';
+import Address from '@/components/address';
+import IndustryCodes from '@/components/industry-codes';
+import PersonList from '@/components/person-list';
 
 export default function CompanyPage({ params }: { params: { source_id: string } }) {
   const { data, isLoading } = useCompanyDetail(params.source_id);
@@ -8,11 +11,23 @@ export default function CompanyPage({ params }: { params: { source_id: string } 
   if (isLoading) return <div>Loading...</div>;
   if (!data) return <div>Not found</div>;
 
-  const { company, events } = data;
+  const { company, events, persons, industry_codes } = data;
 
   return (
     <div className="space-y-4">
       <h1 className="text-2xl font-bold">{company.name}</h1>
+      <div>
+        <h2 className="font-medium">Address</h2>
+        <Address company={company} />
+      </div>
+      <div>
+        <h2 className="font-medium">Industry</h2>
+        <IndustryCodes codes={industry_codes} />
+      </div>
+      <div>
+        <h2 className="font-medium">Persons</h2>
+        <PersonList persons={persons} />
+      </div>
       <div>
         <h2 className="font-medium">Coordinates</h2>
         <div className="h-48 bg-muted flex items-center justify-center">
@@ -22,7 +37,7 @@ export default function CompanyPage({ params }: { params: { source_id: string } 
       <div>
         <h2 className="font-medium">Events</h2>
         <ul className="list-disc pl-5 space-y-1">
-          {events?.map((e: any, idx: number) => (
+          {events?.map((e, idx) => (
             <li key={e.event_id ?? idx}>
               {e.event_date ? `${e.event_date}: ` : ''}
               {e.event_type}

--- a/frontend/components/address.tsx
+++ b/frontend/components/address.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { CompanyDetailCompany } from '@/lib/schemas';
+
+export default function Address({ company }: { company: CompanyDetailCompany }) {
+  const { street, postal_code, city, state, country } = company;
+  if (!street && !postal_code && !city && !state && !country) {
+    return <div>No address</div>;
+  }
+  return (
+    <div className="space-y-1">
+      {street && <div>{street}</div>}
+      {(postal_code || city) && (
+        <div>{[postal_code, city].filter(Boolean).join(' ')}</div>
+      )}
+      {state && <div>{state}</div>}
+      {country && <div>{country}</div>}
+    </div>
+  );
+}

--- a/frontend/components/industry-codes.tsx
+++ b/frontend/components/industry-codes.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { IndustryCode } from '@/lib/schemas';
+
+export default function IndustryCodes({ codes }: { codes: IndustryCode[] }) {
+  if (!codes || codes.length === 0) {
+    return <div>No industry codes</div>;
+  }
+  return (
+    <ul className="list-disc pl-5 space-y-1">
+      {codes.map((c) => (
+        <li key={`${c.scheme}-${c.code}`}>
+          {c.scheme}: {c.code}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/components/person-list.tsx
+++ b/frontend/components/person-list.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Person } from '@/lib/schemas';
+
+export default function PersonList({ persons }: { persons: Person[] }) {
+  if (!persons || persons.length === 0) {
+    return <div>No persons</div>;
+  }
+  return (
+    <ul className="list-disc pl-5 space-y-1">
+      {persons.map((p) => (
+        <li key={p.source_person_id}>
+          {[p.first_name, p.last_name].filter(Boolean).join(' ')}
+          {p.roles && p.roles.length > 0 && (
+            <ul className="ml-4 list-disc space-y-1">
+              {p.roles.map((r, idx) => (
+                <li key={idx}>
+                  {[r.role_name, r.role_type, r.role_date].filter(Boolean).join(' - ')}
+                </li>
+              ))}
+            </ul>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/lib/queries.ts
+++ b/frontend/lib/queries.ts
@@ -1,7 +1,12 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { api } from "./api";
 import { env } from "./env";
-import { SearchRequest, SearchResponse, ImportResponse } from "./schemas";
+import {
+  SearchRequest,
+  SearchResponse,
+  ImportResponse,
+  CompanyDetailResponse
+} from "./schemas";
 import { sleep } from "./utils";
 
 export function useSearchCompanies(request: SearchRequest) {
@@ -16,11 +21,11 @@ export function useSearchCompanies(request: SearchRequest) {
 }
 
 export function useCompanyDetail(id: string) {
-  return useQuery({
+  return useQuery<CompanyDetailResponse>({
     queryKey: ["company", id],
     enabled: !!id,
     queryFn: async () => {
-      const { data } = await api.get(`/api/companies/${id}`);
+      const { data } = await api.get<CompanyDetailResponse>(`/api/companies/${id}`);
       return data;
     }
   });

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -44,3 +44,56 @@ export const ImportResponseSchema = z.object({
   task_id: z.string()
 });
 export type ImportResponse = z.infer<typeof ImportResponseSchema>;
+
+export const EventSchema = z.object({
+  event_id: z.number().optional(),
+  event_date: z.string().optional(),
+  event_type: z.string().optional(),
+  description: z.string().optional()
+});
+export type Event = z.infer<typeof EventSchema>;
+
+export const PersonRoleSchema = z.object({
+  role_name: z.string().optional(),
+  role_type: z.string().optional(),
+  role_date: z.string().optional()
+});
+
+export const PersonSchema = z.object({
+  source_person_id: z.string(),
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  birth_date: z.string().optional(),
+  roles: z.array(PersonRoleSchema)
+});
+export type Person = z.infer<typeof PersonSchema>;
+
+export const IndustryCodeSchema = z.object({
+  scheme: z.string(),
+  code: z.string()
+});
+
+export const CompanyDetailCompanySchema = CompanySchema.extend({
+  raw_name: z.string().optional(),
+  legal_form: z.string().optional(),
+  street: z.string().optional(),
+  postal_code: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  country: z.string().optional(),
+  register_id: z.string().optional(),
+  register_city: z.string().optional(),
+  register_country: z.string().optional(),
+  register_unique_key: z.string().optional(),
+  status: z.string().optional(),
+  terminated: z.boolean().optional()
+});
+export type CompanyDetailCompany = z.infer<typeof CompanyDetailCompanySchema>;
+
+export const CompanyDetailResponseSchema = z.object({
+  company: CompanyDetailCompanySchema,
+  events: z.array(EventSchema),
+  persons: z.array(PersonSchema),
+  industry_codes: z.array(IndustryCodeSchema)
+});
+export type CompanyDetailResponse = z.infer<typeof CompanyDetailResponseSchema>;


### PR DESCRIPTION
## Summary
- add Person and CompanyDetailResponse schemas and types
- show address, industry codes, and related persons on company page
- type useCompanyDetail query and add UI components

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c7ec4c7af483238c93565c3a822ac7