### PR TITLE
Add helper script for quick local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 This project provides an API for managing company data in Germany.
 
+## Schnellstart
+
+F\u00fcr eine lokale Entwicklungsumgebung mit Docker steht ein Hilfsskript bereit:
+
+```bash
+./scripts/dev-start.sh
+```
+
+Das Skript kopiert bei Bedarf die Beispieldatei `.env.example`, startet alle Docker-Services
+und f\u00fchrt s\u00e4mtliche SQL-Migrationen aus. Anschlie\u00dfend ist das Backend unter
+<http://localhost:8080> erreichbar. Das Frontend kann danach mit
+
+```bash
+cd frontend
+npm install
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080 npm run dev
+```
+
+gestartet werden.
+
 ## Lokale Installation auf macOS
 
 1. Voraussetzungen installieren (einmalig):

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+# Ensure .env exists
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+# Start services
+if ! docker compose ps >/dev/null 2>&1; then
+  echo "Docker compose not installed or not running?" >&2
+  exit 1
+fi
+
+docker compose up -d --build
+
+# Run migrations
+for f in backend/migrations/*.sql; do
+  docker compose exec -T db psql -U postgres -d companies -f "$f"
+done
+
+echo "Backend running at http://localhost:8080" 
+
+echo "Start frontend: (cd frontend && npm install && NEXT_PUBLIC_API_BASE_URL=http://localhost:8080 npm run dev)"


### PR DESCRIPTION
## Summary
- add `scripts/dev-start.sh` to start Docker services and run migrations automatically
- document usage of the helper script in a new "Schnellstart" section of the README

## Testing
- `black backend`
- `ruff check backend`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c7bc39626c8323856502753a89722e