### PR TITLE
Pipe migration SQL through stdin

### DIFF
--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -16,7 +16,7 @@ docker compose up -d --build
 
 # Run migrations
 for f in backend/migrations/*.sql; do
-  docker compose exec -T db psql -U postgres -d companies -f "$f"
+  docker compose exec -T db psql -U postgres -d companies < "$f"
 done
 
 echo "Backend running at http://localhost:8080" 


### PR DESCRIPTION
## Summary
- stream each migration file into the database container over STDIN instead of relying on `psql -f`

## Testing
- ./scripts/dev-start.sh *(fails: Docker compose not installed or not running?)*

------
https://chatgpt.com/codex/tasks/task_b_68c8343d12548323b0d996e13d61dac6