### PR TITLE
Persist uploaded import files for Celery processing

### DIFF
--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -1,5 +1,8 @@
 from fastapi import APIRouter, Form, UploadFile
-from uuid import uuid4
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from ..workers.tasks_import import run_import
 
 from ..schemas.import_ import ImportResponse
 
@@ -11,5 +14,28 @@ async def create_import(
     label: str = Form(...), file: UploadFile | None = None
 ) -> ImportResponse:
     filename = file.filename if file else ""
-    task_id = uuid4().hex
-    return ImportResponse(import_label=label, s3_key=filename, task_id=task_id)
+    if file:
+        suffix = Path(filename).suffix if filename else ""
+
+        await file.seek(0)
+
+        with NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            while True:
+                chunk = await file.read(1024 * 1024)
+                if not chunk:
+                    break
+                tmp.write(chunk)
+            temp_path = tmp.name
+
+        await file.close()
+
+        task = run_import.delay(temp_path)
+        task_id = task.id
+    else:
+        task_id = ""
+
+    return ImportResponse(
+        import_label=label,
+        s3_key=filename,
+        task_id=task_id,
+    )


### PR DESCRIPTION
## Summary
- store the uploaded import file in a temporary location for the Celery worker
- trigger the `run_import` task with the temporary file path and return its task id

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c86912a8508323a3a672fb114a74a2