### PR TITLE
Use shared import volume

### DIFF
--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -2,11 +2,14 @@ from fastapi import APIRouter, Form, UploadFile
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from ..workers.tasks_import import run_import
+from ..workers.tasks_import import cleanup_import_file, run_import
 
 from ..schemas.import_ import ImportResponse
 
 router = APIRouter(prefix="/api/imports", tags=["imports"])
+
+
+IMPORTS_DIR = Path("/data/imports")
 
 
 @router.post("", response_model=ImportResponse)
@@ -18,8 +21,9 @@ async def create_import(
         suffix = Path(filename).suffix if filename else ""
 
         await file.seek(0)
+        IMPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
-        with NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        with NamedTemporaryFile(delete=False, dir=IMPORTS_DIR, suffix=suffix) as tmp:
             while True:
                 chunk = await file.read(1024 * 1024)
                 if not chunk:
@@ -29,7 +33,10 @@ async def create_import(
 
         await file.close()
 
-        task = run_import.delay(temp_path)
+        task = run_import.apply_async(
+            args=[temp_path],
+            link=cleanup_import_file.s(),
+        )
         task_id = task.id
     else:
         task_id = ""

--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from sqlalchemy import text
 
@@ -175,3 +176,16 @@ def finalize_import(run_id: int) -> int:
     index_companies(client, companies)
 
     return run_id
+
+
+@celery_app.task
+def cleanup_import_file(file_path: str) -> str:
+    """Delete a temporary import file once it is no longer needed."""
+
+    path = Path(file_path)
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+    return file_path

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - redis
       - opensearch
       - minio
+    volumes:
+      - import_tmp:/data/imports
   worker:
     build: ./backend
     env_file: .env
@@ -18,6 +20,8 @@ services:
       - redis
       - opensearch
       - minio
+    volumes:
+      - import_tmp:/data/imports
   db:
     image: postgis/postgis:16-3.4
     environment:
@@ -51,3 +55,5 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
+volumes:
+  import_tmp:


### PR DESCRIPTION
## Summary
- add a named Docker volume for import files and mount it in the backend and worker services
- store uploaded import files in the shared volume and schedule a cleanup task once the import is complete
- add a Celery task that removes processed import files from the shared volume

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68c8fc4f87bc8323bb54cf5ab5b28ef8