### PR TITLE
Add staging company industries migration

### DIFF
--- a/backend/migrations/0008_add_staging_company_industries.sql
+++ b/backend/migrations/0008_add_staging_company_industries.sql
@@ -1,0 +1,10 @@
+-- Migration to add staging_company_industries table
+CREATE TABLE IF NOT EXISTS staging_company_industries (
+    source_id TEXT,
+    scheme TEXT,
+    code TEXT,
+    run_id BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_staging_company_industries_source
+    ON staging_company_industries(source_id);


### PR DESCRIPTION
## Summary
- add a migration creating the staging_company_industries table with the requested columns
- add an optional index on source_id for the staging_company_industries table

## Testing
- psql -f backend/migrations/0008_add_staging_company_industries.sql *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c900867a988323a42e6cac9159c081