### PR TITLE
Add migration for person source unique constraint

### DIFF
--- a/backend/migrations/0009_add_persons_source_unique.sql
+++ b/backend/migrations/0009_add_persons_source_unique.sql
@@ -1,0 +1,4 @@
+BEGIN;
+ALTER TABLE persons
+  ADD CONSTRAINT persons_source_person_id_key UNIQUE (source_person_id);
+COMMIT;


### PR DESCRIPTION
## Summary
- add migration to enforce uniqueness on persons.source_person_id

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c90a6afae0832380c171445ad16276