### PR TITLE
Handle dataclass slots compatibility

### DIFF
--- a/scripts/validate_jsonl.py
+++ b/scripts/validate_jsonl.py
@@ -10,13 +10,19 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+if sys.version_info >= (3, 10):
+    dataclass_decorator = dataclass(slots=True)
+else:  # pragma: no cover - older Python support
+    dataclass_decorator = dataclass
+
+
 if __package__ is None or __package__ == "":  # pragma: no cover - runtime safety
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from backend.app.workers.tasks_import import run_import
 
 
-@dataclass(slots=True)
+@dataclass_decorator
 class ValidationReport:
     """Result of validating a JSONL file."""
 


### PR DESCRIPTION
## Summary
- make the `ValidationReport` dataclass use `slots` only when running on Python 3.10+

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c9615ca41c83239e40f30a63916523