### PR TITLE
Extend company person roles with description and demotion

### DIFF
--- a/backend/app/utils/staging_loader.py
+++ b/backend/app/utils/staging_loader.py
@@ -73,10 +73,10 @@ def load_to_staging(rows: List[Dict], run_id: int) -> None:
                         "INSERT INTO staging_company_person_roles "
                         "("
                         "source_id, source_person_id, role_name, "
-                        "role_type, role_date, run_id"
+                        "role_type, role_date, description, demotion, run_id"
                         ") "
                         "VALUES (:source_id, :source_person_id, :role_name, "
-                        ":role_type, :role_date, :run_id)"
+                        ":role_type, :role_date, :description, :demotion, :run_id)"
                     ),
                     {
                         "source_id": role.get("source_id"),
@@ -84,6 +84,8 @@ def load_to_staging(rows: List[Dict], run_id: int) -> None:
                         "role_name": role.get("role_name"),
                         "role_type": role.get("role_type"),
                         "role_date": role.get("role_date"),
+                        "description": role.get("description"),
+                        "demotion": role.get("demotion"),
                         "run_id": run_id,
                     },
                 )
@@ -256,7 +258,7 @@ def promote_staging(run_id: int) -> None:
             text(
                 """
                 INSERT INTO company_person_roles (
-                    source_id, person_id, role_name, role_type, role_date, run_id
+                    source_id, person_id, role_name, role_type, role_date, description, demotion, run_id
                 )
                 SELECT
                     scpr.source_id,
@@ -264,6 +266,8 @@ def promote_staging(run_id: int) -> None:
                     scpr.role_name,
                     scpr.role_type,
                     scpr.role_date,
+                    scpr.description,
+                    scpr.demotion,
                     scpr.run_id
                 FROM staging_company_person_roles scpr
                 JOIN persons p ON p.source_person_id = scpr.source_person_id

--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -93,7 +93,9 @@ def run_import(self, s3_key: str) -> str:
                 if not source_person_id:
                     continue
                 persons.append({"source_person_id": source_person_id, "data": p})
+                description = rp.get("description")
                 for role in rp.get("roles", []):
+                    demotion = role.get("demotion")
                     roles.append(
                         {
                             "source_id": data["id"],
@@ -101,6 +103,8 @@ def run_import(self, s3_key: str) -> str:
                             "role_name": role.get("name"),
                             "role_type": role.get("type"),
                             "role_date": role.get("date"),
+                            "description": description,
+                            "demotion": demotion,
                         }
                     )
 

--- a/backend/migrations/0010_extend_roles.sql
+++ b/backend/migrations/0010_extend_roles.sql
@@ -1,0 +1,7 @@
+ALTER TABLE company_person_roles
+  ADD COLUMN description TEXT,
+  ADD COLUMN demotion BOOLEAN;
+
+ALTER TABLE staging_company_person_roles
+  ADD COLUMN description TEXT,
+  ADD COLUMN demotion BOOLEAN;


### PR DESCRIPTION
## Summary
- add a migration that adds description and demotion columns to role tables
- import description and demotion for related person roles into staging and primary tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c96d7ee6808323b68562c572c42f16