### PR TITLE
Add company relations import pipeline

### DIFF
--- a/backend/app/utils/staging_loader.py
+++ b/backend/app/utils/staging_loader.py
@@ -105,6 +105,35 @@ def load_to_staging(rows: List[Dict], run_id: int) -> None:
                     },
                 )
 
+            for relation in row.get("relations", []):
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO staging_company_relations (
+                            source_id,
+                            related_source_id,
+                            relation_type,
+                            description,
+                            run_id
+                        )
+                        VALUES (
+                            :source_id,
+                            :related_source_id,
+                            :relation_type,
+                            :description,
+                            :run_id
+                        )
+                        """
+                    ),
+                    {
+                        "source_id": relation.get("source_id"),
+                        "related_source_id": relation.get("related_source_id"),
+                        "relation_type": relation.get("relation_type"),
+                        "description": relation.get("description"),
+                        "run_id": run_id,
+                    },
+                )
+
 
 def promote_staging(run_id: int) -> None:
     """Move data from staging tables into the main tables.
@@ -258,7 +287,14 @@ def promote_staging(run_id: int) -> None:
             text(
                 """
                 INSERT INTO company_person_roles (
-                    source_id, person_id, role_name, role_type, role_date, description, demotion, run_id
+                    source_id,
+                    person_id,
+                    role_name,
+                    role_type,
+                    role_date,
+                    description,
+                    demotion,
+                    run_id
                 )
                 SELECT
                     scpr.source_id,
@@ -297,6 +333,43 @@ def promote_staging(run_id: int) -> None:
                 INSERT INTO company_industries (source_id, scheme, code, run_id)
                 SELECT source_id, scheme, code, run_id
                 FROM staging_company_industries
+                WHERE run_id = :run_id
+                """
+            ),
+            {"run_id": run_id},
+        )
+
+        # Replace relations for affected companies
+        conn.execute(
+            text(
+                """
+                DELETE FROM company_relations WHERE source_id IN (
+                    SELECT source_id
+                    FROM staging_company_relations
+                    WHERE run_id = :run_id
+                )
+                """
+            ),
+            {"run_id": run_id},
+        )
+
+        conn.execute(
+            text(
+                """
+                INSERT INTO company_relations (
+                    source_id,
+                    related_source_id,
+                    relation_type,
+                    description,
+                    run_id
+                )
+                SELECT
+                    source_id,
+                    related_source_id,
+                    relation_type,
+                    description,
+                    run_id
+                FROM staging_company_relations
                 WHERE run_id = :run_id
                 """
             ),

--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -34,7 +34,10 @@ def run_import(self, s3_key: str) -> str:
 
         with engine.begin() as conn:
             run_id = conn.execute(
-                text("INSERT INTO ingestion_run (source) VALUES (:src) RETURNING run_id"),
+                text(
+                    "INSERT INTO ingestion_run (source) VALUES (:src) "
+                    "RETURNING run_id"
+                ),
                 {"src": "file"},
             ).scalar_one()
 
@@ -119,6 +122,28 @@ def run_import(self, s3_key: str) -> str:
                         }
                     )
 
+            relations: list[dict] = []
+            for rel in data.get("relatedCompanies", {}).get("items", []):
+                related_company = rel.get("company", {})
+                related_source_id = related_company.get("id")
+                if not related_source_id:
+                    continue
+
+                roles = rel.get("roles") or [None]
+                for role in roles:
+                    relation_type = None
+                    if role:
+                        relation_type = role.get("type") or role.get("name")
+
+                    relations.append(
+                        {
+                            "source_id": data["id"],
+                            "related_source_id": related_source_id,
+                            "relation_type": relation_type,
+                            "description": rel.get("description"),
+                        }
+                    )
+
             rows.append(
                 {
                     "company": company.model_dump(),
@@ -126,6 +151,7 @@ def run_import(self, s3_key: str) -> str:
                     "persons": persons,
                     "roles": roles,
                     "industries": industries,
+                    "relations": relations,
                 }
             )
             processed += 1

--- a/backend/migrations/0011_add_company_relations.sql
+++ b/backend/migrations/0011_add_company_relations.sql
@@ -1,0 +1,19 @@
+CREATE TABLE company_relations (
+  cr_id BIGSERIAL PRIMARY KEY,
+  source_id TEXT NOT NULL,
+  related_source_id TEXT NOT NULL,
+  relation_type TEXT,
+  description TEXT,
+  run_id BIGINT REFERENCES ingestion_run(run_id)
+);
+
+CREATE TABLE staging_company_relations (
+  source_id TEXT,
+  related_source_id TEXT,
+  relation_type TEXT,
+  description TEXT,
+  run_id BIGINT
+);
+
+CREATE INDEX idx_company_relations_source ON company_relations(source_id);
+CREATE INDEX idx_staging_company_relations_source ON staging_company_relations(source_id);


### PR DESCRIPTION
## Summary
- add migration introducing company_relations and staging tables for related companies
- capture related company data during import and load it through staging into the main table

## Testing
- ruff check backend

------
https://chatgpt.com/codex/tasks/task_b_68c96e6550d88323b0ee0770cb8c74c2