### PR TITLE
Add migration for persons source unique constraint

### DIFF
--- a/backend/migrations/0012_persons_source_unique.sql
+++ b/backend/migrations/0012_persons_source_unique.sql
@@ -1,0 +1,1 @@
+ALTER TABLE persons ADD CONSTRAINT persons_source_person_id_key UNIQUE (source_person_id);


### PR DESCRIPTION
## Summary
- add migration to enforce a unique constraint on `persons.source_person_id`

## Testing
- not run (psql not available in environment)


------
https://chatgpt.com/codex/tasks/task_b_68c9b16a90b883238a5a6a890d4b649c