### PR TITLE
Handle empty lat/lng values when promoting staging data

### DIFF
--- a/backend/app/utils/staging_loader.py
+++ b/backend/app/utils/staging_loader.py
@@ -168,8 +168,8 @@ def promote_staging(run_id: int) -> None:
                     data->>'city',
                     data->>'state',
                     COALESCE(data->>'country', 'DE'),
-                    (data->>'lat')::double precision,
-                    (data->>'lng')::double precision,
+                    NULLIF(data->>'lat', '')::double precision,
+                    NULLIF(data->>'lng', '')::double precision,
                     data->>'register_id',
                     data->>'register_city',
                     data->>'register_country',
@@ -223,8 +223,8 @@ def promote_staging(run_id: int) -> None:
                     data->'address'->>'city',
                     data->'address'->>'state',
                     COALESCE(data->'address'->>'country', 'DE'),
-                    (data->'address'->>'lat')::double precision,
-                    (data->'address'->>'lng')::double precision,
+                    NULLIF(data->'address'->>'lat', '')::double precision,
+                    NULLIF(data->'address'->>'lng', '')::double precision,
                     data
                 FROM staging_persons
                 WHERE run_id = :run_id


### PR DESCRIPTION
## Summary
- prevent casting errors when lat/lng fields are empty strings by wrapping them in NULLIF before casting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c9b26a0c348323bbf463749857e90a