### PR TITLE
Ensure migrations run before Celery worker starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,7 @@ gestartet werden.
 4. SQL-Migrationen ausführen:
 
    ```bash
-   for f in backend/migrations/*.sql; do
-     docker compose exec -T db psql -U postgres -d companies -f "$f"
-   done
+   docker compose run --rm backend python scripts/run_migrations.py
    ```
 
 5. Frontend starten (optional):
@@ -105,7 +103,8 @@ Die API ist anschlie\u00dfend unter <http://localhost:8080> erreichbar und die W
    S3_ENDPOINT_URL=http://localhost:9000
    ```
 
-   Starte PostgreSQL, Redis, OpenSearch und MinIO auf den entsprechenden Ports und führe die SQL-Skripte in `backend/migrations` in deiner Datenbank aus.
+   Starte PostgreSQL, Redis, OpenSearch und MinIO auf den entsprechenden Ports und führe die SQL-Skripte in `backend/migrations`
+   (z. B. mit `python backend/scripts/run_migrations.py`) in deiner Datenbank aus.
 
 5. Backend starten:
 
@@ -132,9 +131,7 @@ Die API ist anschließend unter <http://localhost:8080> erreichbar und die Webob
 ```bash
 cp .env.example .env
 docker compose up --build
-for f in backend/migrations/*.sql; do
-  docker compose exec -T db psql -U postgres -d companies -f "$f"
-done
+docker compose run --rm backend python scripts/run_migrations.py
 ```
 
 Swagger UI: <http://localhost:8080/docs>
@@ -155,6 +152,10 @@ Start the Celery worker before triggering an import:
 ```bash
 docker compose up worker
 ```
+
+Der Worker führt vor dem Start automatisch `scripts/run_migrations.py` aus, damit
+alle SQL-Migrationen—including die Erweiterung der `persons`-Tabelle und die
+Unique-Constraint—angewendet sind.
 
 Then run the import:
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,5 +3,8 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app ./app
+COPY migrations ./migrations
+COPY scripts ./scripts
+RUN chmod +x scripts/start_worker.sh
 ENV PYTHONPATH=/app
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/scripts/run_migrations.py
+++ b/backend/scripts/run_migrations.py
@@ -1,0 +1,107 @@
+"""Utility to apply SQL migrations in order.
+
+This script ensures each migration runs at most once by recording executed
+filenames in the ``schema_migrations`` table. It can be used from Docker
+containers and local development environments alike.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from psycopg2 import Error
+
+from app.db import engine
+
+LOGGER = logging.getLogger(__name__)
+
+# SQLSTATE error codes that indicate an idempotent migration has already been
+# applied. These cover duplicate column/constraint/index definitions produced
+# when re-running ALTER/CREATE statements.
+IGNORED_SQLSTATES: set[str] = {"42701", "42P07", "42710"}
+
+
+def _get_migration_paths() -> list[Path]:
+    root_dir = Path(__file__).resolve().parents[1]
+    migrations_dir = root_dir / "migrations"
+    if not migrations_dir.exists():
+        raise FileNotFoundError(f"Migrations directory not found: {migrations_dir}")
+    return sorted(migrations_dir.glob("*.sql"))
+
+
+def apply_migrations() -> None:
+    paths = _get_migration_paths()
+    if not paths:
+        LOGGER.info("No migrations found, skipping.")
+        return
+
+    raw_conn = engine.raw_connection()
+    try:
+        raw_conn.autocommit = True
+        with raw_conn.cursor() as cursor:
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    filename TEXT PRIMARY KEY,
+                    executed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """
+            )
+
+            for path in paths:
+                filename = path.name
+                cursor.execute(
+                    "SELECT 1 FROM schema_migrations WHERE filename = %s", (filename,)
+                )
+                if cursor.fetchone():
+                    LOGGER.info("Skipping %s (already applied).", filename)
+                    continue
+
+                sql = path.read_text(encoding="utf-8").strip()
+                if not sql:
+                    LOGGER.info("Skipping %s (empty file).", filename)
+                    cursor.execute(
+                        "INSERT INTO schema_migrations (filename) VALUES (%s)",
+                        (filename,),
+                    )
+                    continue
+
+                LOGGER.info("Applying migration %s", filename)
+                record_as_applied = False
+                try:
+                    cursor.execute(sql)
+                except Error as exc:  # pragma: no cover - defensive
+                    raw_conn.rollback()
+                    if getattr(exc, "pgcode", None) in IGNORED_SQLSTATES:
+                        LOGGER.info(
+                            "Migration %s already applied (%s), recording as completed.",
+                            filename,
+                            exc.pgcode,
+                        )
+                        record_as_applied = True
+                    else:
+                        LOGGER.error(
+                            "Failed to apply migration %s: %s", filename, exc.pgerror
+                        )
+                        raise
+                else:
+                    record_as_applied = True
+                    LOGGER.info("Migration %s applied successfully", filename)
+
+                if record_as_applied:
+                    cursor.execute(
+                        """
+                        INSERT INTO schema_migrations (filename)
+                        VALUES (%s)
+                        ON CONFLICT (filename) DO NOTHING
+                        """,
+                        (filename,),
+                    )
+    finally:
+        raw_conn.close()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    apply_migrations()

--- a/backend/scripts/start_worker.sh
+++ b/backend/scripts/start_worker.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -euo pipefail
+
+python scripts/run_migrations.py
+exec celery -A app.workers.celery_app worker -l info

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,8 @@ services:
   worker:
     build: ./backend
     env_file: .env
-    command: celery -A app.workers.celery_app worker -l info
+    command:
+      - ./scripts/start_worker.sh
     depends_on:
       - db
       - redis

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -14,7 +14,8 @@ if ! docker compose ps >/dev/null 2>&1; then
   exit 1
 fi
 
-docker compose up -d --build
+docker compose build backend
+docker compose up -d --build db redis opensearch minio
 
 # Wait for Postgres
 until docker compose exec db pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB" >/dev/null 2>&1; do
@@ -26,10 +27,11 @@ until curl -sSf http://localhost:9200 >/dev/null 2>&1; do
   sleep 1
 done
 
-# Run migrations
-for f in backend/migrations/*.sql; do
-  docker compose exec -T db psql -U postgres -d companies < "$f"
-done
+# Run migrations using the backend image so the worker sees the same state
+docker compose run --rm backend python scripts/run_migrations.py
+
+# Start application services after the schema is up-to-date
+docker compose up -d --build backend worker
 
 echo "Backend running at http://localhost:8080" 
 


### PR DESCRIPTION
## Summary
- add a reusable migration runner that executes pending SQL files once and records them in `schema_migrations`
- execute the migration runner from the Celery worker start script and package migrations/scripts in the backend image
- update the dev start script and README to run migrations before launching long-running services

## Testing
- pytest -q
- docker compose up worker *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9bd8356dc832389e6d99f7c612232