### PR TITLE
Normalize birth date parsing for imports

### DIFF
--- a/backend/app/utils/date_normalization.py
+++ b/backend/app/utils/date_normalization.py
@@ -1,0 +1,39 @@
+"""Utilities for normalizing date values from external sources."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable
+
+_ALLOWED_FORMATS: tuple[str, ...] = (
+    "%Y-%m-%d",
+    "%d.%m.%Y",
+    "%d/%m/%Y",
+    "%d-%m-%Y",
+    "%m/%d/%Y",
+    "%Y/%m/%d",
+)
+
+
+def _iter_parse_formats(value: str, formats: Iterable[str]) -> str | None:
+    for fmt in formats:
+        try:
+            parsed = datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+        else:
+            return parsed.isoformat()
+    return None
+
+
+def normalize_birth_date(raw: str | None) -> str | None:
+    """Normalize a raw birth date value into an ISO formatted string."""
+
+    if raw is None:
+        return None
+
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+
+    return _iter_parse_formats(cleaned, _ALLOWED_FORMATS)

--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -6,6 +6,7 @@ from sqlalchemy import text
 from .celery_app import celery_app
 from ..db import engine
 from ..schemas.company import Company, Event
+from ..utils.date_normalization import normalize_birth_date
 from ..utils.staging_loader import load_to_staging, promote_staging
 from ..opensearch_client import (
     ensure_companies_index,
@@ -95,7 +96,20 @@ def run_import(self, s3_key: str) -> str:
                 source_person_id = p.get("id")
                 if not source_person_id:
                     continue
-                persons.append({"source_person_id": source_person_id, "data": p})
+                person_data = dict(p)
+                raw_birth = person_data.get("birthDate")
+                if isinstance(raw_birth, str):
+                    normalized_birth = normalize_birth_date(raw_birth)
+                elif raw_birth is not None:
+                    normalized_birth = normalize_birth_date(str(raw_birth))
+                else:
+                    normalized_birth = None
+                if normalized_birth is not None:
+                    person_data["birthDate"] = normalized_birth
+                elif "birthDate" in person_data or raw_birth is not None:
+                    person_data["birthDate"] = None
+
+                persons.append({"source_person_id": source_person_id, "data": person_data})
                 description = rp.get("description")
                 for role in rp.get("roles", []):
                     demotion = role.get("demotion")

--- a/scripts/validate_jsonl.py
+++ b/scripts/validate_jsonl.py
@@ -19,6 +19,7 @@ else:  # pragma: no cover - older Python support
 if __package__ is None or __package__ == "":  # pragma: no cover - runtime safety
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from backend.app.utils.date_normalization import normalize_birth_date
 from backend.app.workers.tasks_import import run_import
 
 
@@ -107,11 +108,26 @@ def validate_jsonl(jsonl_path: Path) -> ValidationReport:
                 else:
                     person_counter[str(source_person_id)] += 1
 
-                for field in ("name", "address", "birthDate"):
+                for field in ("name", "address"):
                     if not _is_value_set(person.get(field)):
                         errors.append(
                             "Zeile "
                             f"{line_number}: relatedPersons.items[{idx}].person.{field} fehlt oder ist leer",
+                        )
+
+                birth_date_raw = person.get("birthDate")
+                if not _is_value_set(birth_date_raw):
+                    errors.append(
+                        "Zeile "
+                        f"{line_number}: relatedPersons.items[{idx}].person.birthDate fehlt oder ist leer",
+                    )
+                else:
+                    normalized_birth_date = normalize_birth_date(str(birth_date_raw))
+                    if normalized_birth_date is None:
+                        errors.append(
+                            "Zeile "
+                            f"{line_number}: relatedPersons.items[{idx}].person.birthDate kann nicht interpretiert werden ("
+                            f"{birth_date_raw!r})",
                         )
 
     duplicates = {

--- a/tests/test_staging_loader.py
+++ b/tests/test_staging_loader.py
@@ -11,6 +11,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from backend.app.utils import staging_loader
+from backend.app.utils.date_normalization import normalize_birth_date
 
 
 class FakeConnection:
@@ -102,6 +103,86 @@ def test_promote_staging_allows_empty_birthdate(monkeypatch: pytest.MonkeyPatch)
                     "data": {
                         "name": {"firstName": "Ada", "lastName": "Lovelace"},
                         "birthDate": "",
+                        "address": {},
+                    },
+                }
+            ],
+        }
+    ]
+
+    staging_loader.load_to_staging(rows, run_id=1)
+    staging_loader.promote_staging(run_id=1)
+
+    promoted = tables["persons"]["person-1"]
+    assert promoted["birth_date"] is None
+
+
+def test_promote_staging_normalizes_birthdate(monkeypatch: pytest.MonkeyPatch) -> None:
+    tables: dict[str, Any] = {
+        "staging_companies": [],
+        "staging_persons": [],
+        "persons": {},
+    }
+
+    fake_engine = FakeEngine(tables)
+
+    from backend.app import db as db_module
+
+    monkeypatch.setattr(db_module, "engine", fake_engine)
+
+    raw_birth = "31.05.1978"
+    normalized_birth = normalize_birth_date(raw_birth)
+    assert normalized_birth == "1978-05-31"
+
+    rows = [
+        {
+            "company": {"source_id": "company-1", "raw_name": "Example Corp"},
+            "persons": [
+                {
+                    "source_person_id": "person-1",
+                    "data": {
+                        "name": {"firstName": "Ada", "lastName": "Lovelace"},
+                        "birthDate": normalized_birth,
+                        "address": {},
+                    },
+                }
+            ],
+        }
+    ]
+
+    staging_loader.load_to_staging(rows, run_id=1)
+    staging_loader.promote_staging(run_id=1)
+
+    promoted = tables["persons"]["person-1"]
+    assert promoted["birth_date"] == date(1978, 5, 31)
+
+
+def test_promote_staging_handles_unparseable_birthdate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tables: dict[str, Any] = {
+        "staging_companies": [],
+        "staging_persons": [],
+        "persons": {},
+    }
+
+    fake_engine = FakeEngine(tables)
+
+    from backend.app import db as db_module
+
+    monkeypatch.setattr(db_module, "engine", fake_engine)
+
+    assert normalize_birth_date("nicht-datum") is None
+
+    rows = [
+        {
+            "company": {"source_id": "company-1", "raw_name": "Example Corp"},
+            "persons": [
+                {
+                    "source_person_id": "person-1",
+                    "data": {
+                        "name": {"firstName": "Ada", "lastName": "Lovelace"},
+                        "birthDate": None,
                         "address": {},
                     },
                 }

--- a/tests/test_validate_jsonl.py
+++ b/tests/test_validate_jsonl.py
@@ -97,3 +97,59 @@ def test_validate_jsonl_finds_duplicate_ids(tmp_path: Path) -> None:
 
     assert report.is_valid
     assert report.duplicate_ids == {"person-1": 2}
+
+
+def test_validate_jsonl_accepts_alternative_birthdate_format(tmp_path: Path) -> None:
+    path = write_jsonl(
+        tmp_path,
+        [
+            {
+                "id": "company-1",
+                "relatedPersons": {
+                    "items": [
+                        {
+                            "person": {
+                                "id": "person-1",
+                                "name": "Max Mustermann",
+                                "address": {"city": "Berlin"},
+                                "birthDate": "31.05.1978",
+                            }
+                        }
+                    ]
+                },
+            }
+        ],
+    )
+
+    report = validate_jsonl(path)
+
+    assert report.is_valid
+    assert report.errors == []
+
+
+def test_validate_jsonl_reports_unparseable_birthdate(tmp_path: Path) -> None:
+    path = write_jsonl(
+        tmp_path,
+        [
+            {
+                "id": "company-1",
+                "relatedPersons": {
+                    "items": [
+                        {
+                            "person": {
+                                "id": "person-1",
+                                "name": "Max Mustermann",
+                                "address": {"city": "Berlin"},
+                                "birthDate": "31.05.78",
+                            }
+                        }
+                    ]
+                },
+            }
+        ],
+    )
+
+    report = validate_jsonl(path)
+
+    assert not report.is_valid
+    assert any("birthDate kann nicht interpretiert" in error for error in report.errors)


### PR DESCRIPTION
## Summary
- add a helper to normalize incoming birth date strings across several expected formats
- apply the normalization during staged imports and validation to ensure consistent ISO values or None
- extend validation and staging loader tests to cover accepted formats and graceful failure of invalid dates

## Testing
- pytest tests/test_validate_jsonl.py tests/test_staging_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68ca733563748323a2b78bf59e3e128c