### PR TITLE
Deduplicate person upsert from staging

### DIFF
--- a/backend/app/utils/staging_loader.py
+++ b/backend/app/utils/staging_loader.py
@@ -213,7 +213,7 @@ def promote_staging(run_id: int) -> None:
                     source_person_id, first_name, last_name, birth_date,
                     street, postal_code, city, state, country, lat, lng, data
                 )
-                SELECT
+                SELECT DISTINCT ON (source_person_id)
                     source_person_id,
                     data->'name'->>'firstName',
                     data->'name'->>'lastName',
@@ -228,6 +228,7 @@ def promote_staging(run_id: int) -> None:
                     data
                 FROM staging_persons
                 WHERE run_id = :run_id
+                ORDER BY source_person_id, updated_at DESC
                 ON CONFLICT (source_person_id) DO UPDATE SET
                     first_name = EXCLUDED.first_name,
                     last_name = EXCLUDED.last_name,

--- a/tests/test_staging_loader.py
+++ b/tests/test_staging_loader.py
@@ -195,3 +195,50 @@ def test_promote_staging_handles_unparseable_birthdate(
 
     promoted = tables["persons"]["person-1"]
     assert promoted["birth_date"] is None
+
+
+def test_promote_staging_deduplicates_persons(monkeypatch: pytest.MonkeyPatch) -> None:
+    tables: dict[str, Any] = {
+        "staging_companies": [],
+        "staging_persons": [],
+        "persons": {},
+    }
+
+    fake_engine = FakeEngine(tables)
+
+    from backend.app import db as db_module
+
+    monkeypatch.setattr(db_module, "engine", fake_engine)
+
+    rows = [
+        {
+            "company": {"source_id": "company-1", "raw_name": "Example Corp"},
+            "persons": [
+                {
+                    "source_person_id": "person-1",
+                    "data": {
+                        "name": {"firstName": "Ada", "lastName": "Lovelace"},
+                        "birthDate": "1978-05-31",
+                        "address": {},
+                    },
+                },
+                {
+                    "source_person_id": "person-1",
+                    "data": {
+                        "name": {"firstName": "A.", "lastName": "Lovelace"},
+                        "birthDate": "1978-05-31",
+                        "address": {},
+                    },
+                },
+            ],
+        }
+    ]
+
+    staging_loader.load_to_staging(rows, run_id=1)
+
+    assert len(tables["staging_persons"]) == 2
+
+    staging_loader.promote_staging(run_id=1)
+
+    assert len(tables["persons"]) == 1
+    assert "person-1" in tables["persons"]


### PR DESCRIPTION
## Summary
- ensure staging person upsert selects only one row per source_person_id ordered by latest update
- add regression test covering duplicate staging entries for a single person

## Testing
- pytest tests/test_staging_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68ca84c80a5083239d463f72c290cc94