### PR TITLE
Fix staging person ordering and guard test

### DIFF
--- a/backend/app/utils/staging_loader.py
+++ b/backend/app/utils/staging_loader.py
@@ -228,7 +228,7 @@ def promote_staging(run_id: int) -> None:
                     data
                 FROM staging_persons
                 WHERE run_id = :run_id
-                ORDER BY source_person_id, updated_at DESC
+                ORDER BY source_person_id
                 ON CONFLICT (source_person_id) DO UPDATE SET
                     first_name = EXCLUDED.first_name,
                     last_name = EXCLUDED.last_name,

--- a/tests/test_staging_loader.py
+++ b/tests/test_staging_loader.py
@@ -31,6 +31,7 @@ class FakeConnection:
             return
 
         if "INSERT INTO persons" in sql:
+            assert "updated_at" not in sql
             run_id = params["run_id"]
             use_nullif = "NULLIF(data->>'birthDate', '')::date" in sql
 


### PR DESCRIPTION
## Summary
- ensure staging person promotion orders only by existing columns
- add regression assertion preventing updated_at usage in generated SQL

## Testing
- pytest tests/test_staging_loader.py

------
https://chatgpt.com/codex/tasks/task_b_68ca8b9f3c4883238863cc371c452bb0