### PR TITLE
Handle finalize_import synchronously in CLI

### DIFF
--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -1,5 +1,6 @@
 import json
 from pathlib import Path
+from typing import TypedDict
 
 from sqlalchemy import text
 
@@ -17,8 +18,13 @@ from ..opensearch_client import (
 BATCH_SIZE = 1000
 
 
+class ImportRunResult(TypedDict):
+    s3_key: str
+    run_id: int
+
+
 @celery_app.task(bind=True)
-def run_import(self, s3_key: str) -> str:
+def run_import(self, s3_key: str) -> ImportRunResult:
     """Import companies from an NDJSON file.
 
     The ``s3_key`` parameter is treated as a local file path. Each line is
@@ -181,7 +187,7 @@ def run_import(self, s3_key: str) -> str:
             report_progress()
 
     finalize_import.delay(run_id)
-    return s3_key
+    return {"s3_key": s3_key, "run_id": run_id}
 
 
 @celery_app.task

--- a/scripts/validate_jsonl.py
+++ b/scripts/validate_jsonl.py
@@ -20,7 +20,7 @@ if __package__ is None or __package__ == "":  # pragma: no cover - runtime safet
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from backend.app.utils.date_normalization import normalize_birth_date
-from backend.app.workers.tasks_import import run_import
+from backend.app.workers.tasks_import import finalize_import, run_import
 
 
 @dataclass_decorator
@@ -137,11 +137,20 @@ def validate_jsonl(jsonl_path: Path) -> ValidationReport:
     return ValidationReport(errors=errors, duplicate_ids=sorted_duplicates)
 
 
-def start_import(jsonl_path: Path) -> str:
-    """Run the import task for ``jsonl_path`` synchronously."""
+def start_import(jsonl_path: Path) -> dict[str, int | str]:
+    """Run the import and finalization tasks for ``jsonl_path`` synchronously."""
 
     result = run_import.apply(args=[str(jsonl_path)])
-    return result.get()
+    payload = result.get()
+
+    if not isinstance(payload, dict) or "run_id" not in payload:
+        raise RuntimeError("Importlauf lieferte kein gültiges Ergebnis zurück")
+
+    run_id = payload["run_id"]
+    finalize_result = finalize_import.apply(args=[run_id])
+    finalize_result.get()
+
+    return payload
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tests/test_validate_jsonl.py
+++ b/tests/test_validate_jsonl.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import sys
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from scripts.validate_jsonl import ValidationReport, validate_jsonl
+import scripts.validate_jsonl as validate_jsonl_module
+from scripts.validate_jsonl import ValidationReport, start_import, validate_jsonl
 
 
 def write_jsonl(tmp_path: Path, entries: list[dict]) -> Path:
@@ -153,3 +155,63 @@ def test_validate_jsonl_reports_unparseable_birthdate(tmp_path: Path) -> None:
 
     assert not report.is_valid
     assert any("birthDate kann nicht interpretiert" in error for error in report.errors)
+
+
+class DummyResult:
+    def __init__(self, value: Any) -> None:
+        self._value = value
+
+    def get(self, timeout: float | None = None) -> Any:  # pragma: no cover - signature parity
+        return self._value
+
+
+def test_start_import_promotes_without_worker(monkeypatch, tmp_path: Path) -> None:
+    tables: dict[str, list[dict[str, Any]]] = {"staging": [], "companies": []}
+    promoted_run_ids: list[int] = []
+
+    def fake_run_import_apply(*, args=None, kwargs=None, **_: Any) -> DummyResult:
+        args = args or ()
+        jsonl_arg = args[0] if args else kwargs["jsonl_path"]
+        jsonl_path = Path(jsonl_arg)
+        run_id = 42
+
+        with jsonl_path.open(encoding="utf-8") as handle:
+            for line in handle:
+                data = line.strip()
+                if not data:
+                    continue
+                tables["staging"].append({"run_id": run_id, "company": json.loads(data)})
+
+        return DummyResult({"s3_key": str(jsonl_path), "run_id": run_id})
+
+    def fake_finalize_import_apply(*, args=None, kwargs=None, **_: Any) -> DummyResult:
+        args = args or ()
+        run_id = args[0] if args else kwargs["run_id"]
+        promoted_run_ids.append(run_id)
+
+        for row in list(tables["staging"]):
+            if row["run_id"] == run_id:
+                tables["companies"].append(row["company"])
+                tables["staging"].remove(row)
+
+        return DummyResult(run_id)
+
+    monkeypatch.setattr(validate_jsonl_module.run_import, "apply", fake_run_import_apply)
+    monkeypatch.setattr(validate_jsonl_module.finalize_import, "apply", fake_finalize_import_apply)
+
+    jsonl_path = write_jsonl(
+        tmp_path,
+        [
+            {
+                "id": "company-1",
+                "relatedPersons": {"items": []},
+            }
+        ],
+    )
+
+    result = start_import(jsonl_path)
+
+    assert result == {"s3_key": str(jsonl_path), "run_id": 42}
+    assert promoted_run_ids == [42]
+    assert tables["staging"] == []
+    assert [company["id"] for company in tables["companies"]] == ["company-1"]


### PR DESCRIPTION
## Summary
- return both the S3 key and run identifier from the import task
- ensure the CLI helper triggers finalize_import synchronously based on the returned run_id
- cover the synchronous finalize path with a unit test that simulates staging promotion without a worker

## Testing
- pytest tests/test_validate_jsonl.py

------
https://chatgpt.com/codex/tasks/task_b_68cd2eaaf6048323a5f59bc708e16808