### PR TITLE
Allow missing birthDate fields during JSONL validation

### DIFF
--- a/scripts/validate_jsonl.py
+++ b/scripts/validate_jsonl.py
@@ -20,7 +20,23 @@ if __package__ is None or __package__ == "":  # pragma: no cover - runtime safet
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from backend.app.utils.date_normalization import normalize_birth_date
-from backend.app.workers.tasks_import import finalize_import, run_import
+
+try:
+    from backend.app.workers.tasks_import import finalize_import, run_import
+except ModuleNotFoundError:  # pragma: no cover - optional dependency guard for tests
+    class _DeferredTask:
+        """Placeholder to allow tests to patch Celery tasks when dependencies are missing."""
+
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def apply(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError(
+                f"{self._name} ist nicht verfügbar. Fehlt eine optionale Abhängigkeit?",
+            )
+
+    run_import = _DeferredTask("run_import")
+    finalize_import = _DeferredTask("finalize_import")
 
 
 @dataclass_decorator
@@ -116,12 +132,7 @@ def validate_jsonl(jsonl_path: Path) -> ValidationReport:
                         )
 
                 birth_date_raw = person.get("birthDate")
-                if not _is_value_set(birth_date_raw):
-                    errors.append(
-                        "Zeile "
-                        f"{line_number}: relatedPersons.items[{idx}].person.birthDate fehlt oder ist leer",
-                    )
-                else:
+                if _is_value_set(birth_date_raw):
                     normalized_birth_date = normalize_birth_date(str(birth_date_raw))
                     if normalized_birth_date is None:
                         errors.append(

--- a/tests/test_validate_jsonl.py
+++ b/tests/test_validate_jsonl.py
@@ -77,7 +77,34 @@ def test_validate_jsonl_reports_missing_fields(tmp_path: Path) -> None:
     assert any("person.id" in error for error in report.errors)
     assert any("person.name" in error for error in report.errors)
     assert any("person.address" in error for error in report.errors)
-    assert any("person.birthDate" in error for error in report.errors)
+    assert all("person.birthDate fehlt" not in error for error in report.errors)
+
+
+def test_validate_jsonl_accepts_missing_birthdate(tmp_path: Path) -> None:
+    path = write_jsonl(
+        tmp_path,
+        [
+            {
+                "id": "company-1",
+                "relatedPersons": {
+                    "items": [
+                        {
+                            "person": {
+                                "id": "person-1",
+                                "name": "Max Mustermann",
+                                "address": {"city": "Berlin"},
+                            }
+                        }
+                    ]
+                },
+            }
+        ],
+    )
+
+    report = validate_jsonl(path)
+
+    assert report.is_valid
+    assert report.errors == []
 
 
 def test_validate_jsonl_finds_duplicate_ids(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- stop flagging missing `birthDate` values during JSONL validation while still normalizing present values
- add lightweight fallbacks for Celery tasks so the validator can be imported without optional dependencies
- update validation tests and add a case ensuring records without `birthDate` pass validation

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_validate_jsonl.py

------
https://chatgpt.com/codex/tasks/task_b_68cd2fc6aa888323957c641657864707