### PR TITLE
Handle ImportRunResult cleanup input

### DIFF
--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, Union
 
 from sqlalchemy import text
 
@@ -229,13 +229,19 @@ def finalize_import(run_id: int) -> int:
 
 
 @celery_app.task
-def cleanup_import_file(file_path: str) -> str:
+def cleanup_import_file(
+    result: Union[ImportRunResult, str]
+) -> Union[ImportRunResult, str]:
     """Delete a temporary import file once it is no longer needed."""
 
-    path = Path(file_path)
+    if isinstance(result, str):
+        path = Path(result)
+    else:
+        path = Path(result["s3_key"])
+
     try:
         path.unlink()
     except FileNotFoundError:
         pass
 
-    return file_path
+    return result

--- a/tests/test_cleanup_import_file.py
+++ b/tests/test_cleanup_import_file.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.app.workers.tasks_import import cleanup_import_file
+
+
+def test_cleanup_import_file_handles_import_run_result(tmp_path):
+    file_path = tmp_path / "import.ndjson"
+    file_path.write_text("{}", encoding="utf-8")
+
+    result = {"s3_key": str(file_path), "run_id": 1}
+
+    returned = cleanup_import_file.run(result)
+
+    assert returned == result
+    assert not Path(result["s3_key"]).exists()


### PR DESCRIPTION
## Summary
- allow `cleanup_import_file` to accept either a path string or an import result dictionary and delete the referenced file safely
- ensure the original result is returned for chaining
- add a unit test covering cleanup when invoked with an `ImportRunResult`

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68cd344a4b68832388925362c228df4f