### PR TITLE
Add import run summaries and API endpoint

### DIFF
--- a/backend/app/routers/imports.py
+++ b/backend/app/routers/imports.py
@@ -1,10 +1,14 @@
-from fastapi import APIRouter, Form, UploadFile
+import json
+from fastapi import APIRouter, Form, HTTPException, UploadFile
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from ..workers.tasks_import import cleanup_import_file, run_import
+from sqlalchemy import text
 
-from ..schemas.import_ import ImportResponse
+from ..db import engine
+from ..workers.tasks_import import cleanup_import_file, finalize_import, run_import
+
+from ..schemas.import_ import ImportResponse, ImportSummaryResponse
 
 router = APIRouter(prefix="/api/imports", tags=["imports"])
 
@@ -33,10 +37,8 @@ async def create_import(
 
         await file.close()
 
-        task = run_import.apply_async(
-            args=[temp_path],
-            link=cleanup_import_file.s(),
-        )
+        workflow = run_import.s(temp_path) | finalize_import.s() | cleanup_import_file.s()
+        task = workflow.apply_async()
         task_id = task.id
     else:
         task_id = ""
@@ -45,4 +47,43 @@ async def create_import(
         import_label=label,
         s3_key=filename,
         task_id=task_id,
+    )
+
+
+@router.get("/{run_id}", response_model=ImportSummaryResponse)
+def get_import_summary(run_id: int) -> ImportSummaryResponse:
+    with engine.begin() as conn:
+        row = (
+            conn.execute(
+                text(
+                    """
+                    SELECT run_id, finished_at, summary
+                    FROM ingestion_run
+                    WHERE run_id = :run_id
+                    """
+                ),
+                {"run_id": run_id},
+            )
+            .mappings()
+            .first()
+        )
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="Import run not found")
+
+    summary_value = row.get("summary")
+    if isinstance(summary_value, str):
+        summary = json.loads(summary_value)
+    elif summary_value is None:
+        summary = {}
+    else:
+        summary = dict(summary_value)
+
+    finished_at = row.get("finished_at")
+
+    return ImportSummaryResponse(
+        run_id=row["run_id"],
+        summary=summary,
+        finished=finished_at is not None,
+        finished_at=finished_at,
     )

--- a/backend/app/schemas/import_.py
+++ b/backend/app/schemas/import_.py
@@ -1,7 +1,15 @@
-from pydantic import BaseModel
+from datetime import datetime
+from pydantic import BaseModel, Field
 
 
 class ImportResponse(BaseModel):
     import_label: str
     s3_key: str
     task_id: str
+
+
+class ImportSummaryResponse(BaseModel):
+    run_id: int
+    summary: dict[str, int] = Field(default_factory=dict)
+    finished: bool
+    finished_at: datetime | None = None

--- a/backend/app/workers/tasks_import.py
+++ b/backend/app/workers/tasks_import.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TypedDict, Union
 
@@ -18,9 +19,11 @@ from ..opensearch_client import (
 BATCH_SIZE = 1000
 
 
-class ImportRunResult(TypedDict):
+class ImportRunResult(TypedDict, total=False):
     s3_key: str
     run_id: int
+    summary: dict[str, int]
+    finished_at: str
 
 
 @celery_app.task(bind=True)
@@ -186,13 +189,19 @@ def run_import(self, s3_key: str) -> ImportRunResult:
             rows = []
             report_progress()
 
-    finalize_import.delay(run_id)
     return {"s3_key": s3_key, "run_id": run_id}
 
 
 @celery_app.task
-def finalize_import(run_id: int) -> int:
+def finalize_import(result: Union[ImportRunResult, int]) -> ImportRunResult:
     """Promote staging data for ``run_id`` into the main tables."""
+
+    if isinstance(result, dict):
+        run_id = result["run_id"]
+        run_result: ImportRunResult = dict(result)
+    else:
+        run_id = int(result)
+        run_result = {"run_id": run_id}
 
     promote_staging(run_id)
 
@@ -221,11 +230,52 @@ def finalize_import(run_id: int) -> int:
             .all()
         )
 
+        table_queries = {
+            "companies": "SELECT COUNT(*) FROM companies WHERE seen_in_run = :run_id",
+            "events": "SELECT COUNT(*) FROM events WHERE run_id = :run_id",
+            "company_person_roles": (
+                "SELECT COUNT(*) FROM company_person_roles WHERE run_id = :run_id"
+            ),
+            "company_industries": (
+                "SELECT COUNT(*) FROM company_industries WHERE run_id = :run_id"
+            ),
+            "company_relations": (
+                "SELECT COUNT(*) FROM company_relations WHERE run_id = :run_id"
+            ),
+            "company_history": (
+                "SELECT COUNT(*) FROM company_history WHERE run_id = :run_id"
+            ),
+        }
+
+        summary: dict[str, int] = {}
+        for table_name, query in table_queries.items():
+            count = conn.execute(text(query), {"run_id": run_id}).scalar_one()
+            summary[table_name] = int(count)
+
+        finished_at = datetime.now(timezone.utc)
+        conn.execute(
+            text(
+                """
+                UPDATE ingestion_run
+                SET finished_at = :finished_at,
+                    summary = :summary::jsonb
+                WHERE run_id = :run_id
+                """
+            ),
+            {
+                "finished_at": finished_at,
+                "summary": json.dumps(summary),
+                "run_id": run_id,
+            },
+        )
+
     client = get_opensearch()
     ensure_companies_index(client)
     index_companies(client, companies)
 
-    return run_id
+    run_result["summary"] = summary
+    run_result["finished_at"] = finished_at.isoformat()
+    return run_result
 
 
 @celery_app.task

--- a/backend/migrations/0013_add_ingestion_run_summary.sql
+++ b/backend/migrations/0013_add_ingestion_run_summary.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE ingestion_run
+  ADD COLUMN summary JSONB;
+
+COMMIT;

--- a/tests/test_imports_router.py
+++ b/tests/test_imports_router.py
@@ -1,0 +1,92 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.app import db as db_module
+from backend.app.main import app
+
+
+class FakeResult:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def mappings(self) -> "FakeResult":
+        return self
+
+    def first(self) -> dict[str, Any] | None:
+        return self._rows[0] if self._rows else None
+
+
+class FakeConnection:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def execute(self, statement: Any, params: dict[str, Any] | None = None) -> FakeResult:
+        sql = getattr(statement, "text", str(statement))
+        if "FROM ingestion_run" not in sql:
+            raise AssertionError(f"Unexpected SQL: {sql}")
+        return FakeResult(self._rows)
+
+
+class FakeContext:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def __enter__(self) -> FakeConnection:
+        return FakeConnection(self._rows)
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
+        return False
+
+
+class FakeEngine:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def begin(self) -> FakeContext:
+        return FakeContext(self._rows)
+
+
+def test_get_import_summary_returns_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    finished_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    rows = [
+        {
+            "run_id": 7,
+            "summary": {"companies": 2, "events": 1},
+            "finished_at": finished_at,
+        }
+    ]
+
+    monkeypatch.setattr(db_module, "engine", FakeEngine(rows))
+
+    client = TestClient(app)
+    response = client.get("/api/imports/7")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "run_id": 7,
+        "summary": {"companies": 2, "events": 1},
+        "finished": True,
+        "finished_at": finished_at.isoformat(),
+    }
+
+
+def test_get_import_summary_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(db_module, "engine", FakeEngine([]))
+
+    client = TestClient(app)
+    response = client.get("/api/imports/99")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Import run not found"

--- a/tests/test_tasks_import.py
+++ b/tests/test_tasks_import.py
@@ -1,0 +1,119 @@
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend.app.workers import tasks_import
+
+
+class FakeResult:
+    def __init__(self, *, value: Any | None = None, rows: list[dict[str, Any]] | None = None):
+        self._value = value
+        self._rows = rows or []
+
+    def scalar_one(self) -> Any:
+        if self._value is None:
+            raise AssertionError("No scalar value available")
+        return self._value
+
+    def mappings(self) -> "FakeResult":
+        return self
+
+    def all(self) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.updated_params: dict[str, Any] | None = None
+
+    def execute(self, statement: Any, params: dict[str, Any] | None = None) -> FakeResult:
+        sql = getattr(statement, "text", str(statement))
+        params = params or {}
+
+        if "name_norm AS name" in sql:
+            return FakeResult(rows=[{"source_id": "src-1", "name": "Example"}])
+
+        if "COUNT(*) FROM companies" in sql:
+            return FakeResult(value=3)
+        if "COUNT(*) FROM events" in sql:
+            return FakeResult(value=4)
+        if "COUNT(*) FROM company_person_roles" in sql:
+            return FakeResult(value=5)
+        if "COUNT(*) FROM company_industries" in sql:
+            return FakeResult(value=6)
+        if "COUNT(*) FROM company_relations" in sql:
+            return FakeResult(value=7)
+        if "COUNT(*) FROM company_history" in sql:
+            return FakeResult(value=8)
+
+        if "UPDATE ingestion_run" in sql:
+            self.updated_params = dict(params)
+            return FakeResult()
+
+        raise AssertionError(f"Unexpected SQL: {sql}")
+
+
+class FakeConnectionContext:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    def __enter__(self) -> FakeConnection:
+        return self._connection
+
+    def __exit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
+        return False
+
+
+class FakeEngine:
+    def __init__(self, connection: FakeConnection) -> None:
+        self._connection = connection
+
+    def begin(self) -> FakeConnectionContext:
+        return FakeConnectionContext(self._connection)
+
+
+def test_finalize_import_collects_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = FakeConnection()
+    engine = FakeEngine(connection)
+
+    monkeypatch.setattr(tasks_import, "engine", engine)
+
+    promoted: dict[str, Any] = {}
+    monkeypatch.setattr(tasks_import, "promote_staging", lambda run_id: promoted.setdefault("run_id", run_id))
+
+    indexed: dict[str, Any] = {}
+    monkeypatch.setattr(tasks_import, "get_opensearch", lambda: object())
+    monkeypatch.setattr(tasks_import, "ensure_companies_index", lambda client: indexed.setdefault("ensured", True))
+    monkeypatch.setattr(tasks_import, "index_companies", lambda client, rows: indexed.setdefault("rows", list(rows)))
+
+    start = datetime.now(timezone.utc)
+    result = tasks_import.finalize_import.run({"s3_key": "file.ndjson", "run_id": 42})
+
+    assert promoted["run_id"] == 42
+    assert indexed["ensured"] is True
+    assert indexed["rows"] == [{"source_id": "src-1", "name": "Example"}]
+
+    assert result["run_id"] == 42
+    assert result["summary"] == {
+        "companies": 3,
+        "events": 4,
+        "company_person_roles": 5,
+        "company_industries": 6,
+        "company_relations": 7,
+        "company_history": 8,
+    }
+
+    finished_at = datetime.fromisoformat(result["finished_at"])
+    assert finished_at >= start
+
+    assert connection.updated_params is not None
+    assert connection.updated_params["run_id"] == 42
+    assert json.loads(connection.updated_params["summary"]) == result["summary"]


### PR DESCRIPTION
## Summary
- add a summary column to ingestion runs and record table counts plus `finished_at` during finalization
- expose `GET /api/imports/{run_id}` to return the stored summary and completion status
- chain the import tasks so the final result includes the run metadata and extend the test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd38fc1b348323a8c1cd08aa0100a2