### PR TITLE
Add import summary fetching and display

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/frontend/app/admin/import/page.tsx
+++ b/frontend/app/admin/import/page.tsx
@@ -15,7 +15,8 @@ export default function ImportPage() {
       name: file.name,
       size: file.size,
       status: 'ready' as const,
-      progress: 0
+      progress: 0,
+      summaryStatus: 'idle' as const
     }));
     setItems((prev) => [...prev, ...newItems]);
   }

--- a/frontend/components/import-list.tsx
+++ b/frontend/components/import-list.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useCallback, useEffect, useRef } from 'react';
-import { useCreateImport } from '@/lib/queries';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCreateImport, useImportSummary } from '@/lib/queries';
 import { env } from '@/lib/env';
 import { api } from '@/lib/api';
 import { sleep, formatBytes } from '@/lib/utils';
 import JobStatusBadge, { JobStatus } from './job-status-badge';
 import { toast } from './toast';
+
+type SummaryStatus = 'idle' | 'loading' | 'success' | 'error';
 
 export type ImportItem = {
   id: string;
@@ -17,6 +19,11 @@ export type ImportItem = {
   progress: number;
   taskId?: string;
   error?: string;
+  runId?: number;
+  finishedAt?: string;
+  summary?: Record<string, number>;
+  summaryStatus: SummaryStatus;
+  summaryError?: string;
 };
 
 interface Props {
@@ -33,14 +40,49 @@ export default function ImportList({ label, items, setItems }: Props) {
     async (localId: string, taskId: string) => {
       if (process.env.NODE_ENV !== 'production' && env.fakeTaskPoll) {
         await sleep(2000);
-        setItems((arr) => arr.map((i) => (i.id === localId ? { ...i, status: 'done' } : i)));
+        setItems((arr) =>
+          arr.map((i) =>
+            i.id === localId
+              ? {
+                  ...i,
+                  status: 'done',
+                  summaryStatus: 'success',
+                  summary: i.summary ?? {},
+                }
+              : i
+          )
+        );
         return;
       }
       for (let i = 0; i < 60; i++) {
         try {
           const { data } = await api.get(`/api/tasks/${taskId}`);
           if (data.state === 'SUCCESS') {
-            setItems((arr) => arr.map((i) => (i.id === localId ? { ...i, status: 'done' } : i)));
+            const info = (data.info || data.meta) as Record<string, any> | undefined;
+            const runIdValue = Number(info?.run_id);
+            setItems((arr) =>
+              arr.map((i) => {
+                if (i.id !== localId) return i;
+                if (Number.isFinite(runIdValue)) {
+                  return {
+                    ...i,
+                    status: 'done',
+                    runId: runIdValue,
+                    summary: undefined,
+                    summaryStatus: 'loading',
+                    summaryError: undefined,
+                    finishedAt: typeof info?.finished_at === 'string' ? info.finished_at : undefined,
+                  };
+                }
+                toast.error('Die Run-ID des Imports konnte nicht ermittelt werden.');
+                return {
+                  ...i,
+                  status: 'done',
+                  summaryStatus: 'error',
+                  summaryError: 'Run-ID fehlt',
+                };
+              })
+            );
             return;
           }
           if (data.state === 'FAILURE') {
@@ -69,7 +111,22 @@ export default function ImportList({ label, items, setItems }: Props) {
 
     async function process() {
       try {
-        setItems((arr) => arr.map((i) => (i.id === next.id ? { ...i, status: 'uploading', progress: 0 } : i)));
+        setItems((arr) =>
+          arr.map((i) =>
+            i.id === next.id
+              ? {
+                  ...i,
+                  status: 'uploading',
+                  progress: 0,
+                  runId: undefined,
+                  summary: undefined,
+                  summaryStatus: 'idle',
+                  summaryError: undefined,
+                  finishedAt: undefined,
+                }
+              : i
+          )
+        );
         const res = await createImport.mutateAsync({
           label,
           file: next.file,
@@ -79,12 +136,34 @@ export default function ImportList({ label, items, setItems }: Props) {
           }
         });
         setItems((arr) =>
-          arr.map((i) => (i.id === next.id ? { ...i, status: 'processing', taskId: res.task_id, progress: 100 } : i))
+          arr.map((i) =>
+            i.id === next.id
+              ? {
+                  ...i,
+                  status: 'processing',
+                  taskId: res.task_id,
+                  progress: 100,
+                  summaryStatus: 'idle',
+                }
+              : i
+          )
         );
         await pollTask(next.id, res.task_id);
       } catch (e: any) {
         toast.error(e.message);
-        setItems((arr) => arr.map((i) => (i.id === next.id ? { ...i, status: 'error', error: e.message } : i)));
+        setItems((arr) =>
+          arr.map((i) =>
+            i.id === next.id
+              ? {
+                  ...i,
+                  status: 'error',
+                  error: e.message,
+                  summaryStatus: 'error',
+                  summaryError: e.message,
+                }
+              : i
+          )
+        );
       } finally {
         uploadingRef.current = false;
       }
@@ -94,7 +173,23 @@ export default function ImportList({ label, items, setItems }: Props) {
   }, [items, label, createImport, pollTask, setItems]);
 
   function retry(id: string) {
-    setItems((arr) => arr.map((i) => (i.id === id ? { ...i, status: 'ready', progress: 0, error: undefined } : i)));
+    setItems((arr) =>
+      arr.map((i) =>
+        i.id === id
+          ? {
+              ...i,
+              status: 'ready',
+              progress: 0,
+              error: undefined,
+              summary: undefined,
+              summaryStatus: 'idle',
+              summaryError: undefined,
+              runId: undefined,
+              finishedAt: undefined,
+            }
+          : i
+      )
+    );
   }
 
   function remove(id: string) {
@@ -102,18 +197,41 @@ export default function ImportList({ label, items, setItems }: Props) {
   }
 
   return (
-    <div className="mt-4 space-y-2">
+    <div className="mt-4 space-y-3">
       {items.map((item) => (
-        <div key={item.id} className="p-2 border rounded flex items-center gap-4">
-          <div className="flex-1">
-            <div className="font-medium">{item.name}</div>
-            <div className="text-xs text-muted-foreground">{formatBytes(item.size)}</div>
-            {item.status === 'uploading' && (
-              <div className="w-full bg-secondary h-2 rounded mt-1">
-                <div className="h-2 bg-primary rounded" style={{ width: `${item.progress}%` }} />
-              </div>
-            )}
-          </div>
+        <ImportListItem key={item.id} item={item} remove={remove} retry={retry} setItems={setItems} />
+      ))}
+    </div>
+  );
+}
+
+interface ItemProps {
+  item: ImportItem;
+  setItems: Props['setItems'];
+  remove: (id: string) => void;
+  retry: (id: string) => void;
+}
+
+function ImportListItem({ item, setItems, remove, retry }: ItemProps) {
+  const shouldFetchSummary = useMemo(
+    () => item.summaryStatus === 'loading' && !!item.runId,
+    [item.summaryStatus, item.runId]
+  );
+  useImportSummaryFetcher({ item, setItems, enabled: shouldFetchSummary });
+
+  return (
+    <div className="p-3 border rounded space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex-1">
+          <div className="font-medium break-words">{item.name}</div>
+          <div className="text-xs text-muted-foreground">{formatBytes(item.size)}</div>
+          {item.status === 'uploading' && (
+            <div className="w-full bg-secondary h-2 rounded mt-2 overflow-hidden">
+              <div className="h-2 bg-primary transition-all" style={{ width: `${item.progress}%` }} />
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
           <JobStatusBadge status={item.status} />
           {item.status === 'ready' && (
             <button className="px-2 py-1 text-sm border rounded" onClick={() => remove(item.id)}>
@@ -126,7 +244,126 @@ export default function ImportList({ label, items, setItems }: Props) {
             </button>
           )}
         </div>
-      ))}
+      </div>
+
+      {item.status === 'done' && <ImportSummarySection item={item} />}
     </div>
   );
+}
+
+function ImportSummarySection({ item }: { item: ImportItem }) {
+  if (item.summaryStatus === 'loading') {
+    return <div className="text-sm text-muted-foreground">Zusammenfassung wird geladen...</div>;
+  }
+
+  if (item.summaryStatus === 'error') {
+    return (
+      <div className="text-sm text-destructive">
+        <span className="inline-flex items-center gap-2 rounded border border-destructive/40 bg-destructive/10 px-2 py-1">
+          Fehler beim Laden der Zusammenfassung{item.summaryError ? `: ${item.summaryError}` : ''}
+        </span>
+      </div>
+    );
+  }
+
+  const summaryEntries = Object.entries(item.summary ?? {});
+
+  if (summaryEntries.length === 0) {
+    return <div className="text-sm text-muted-foreground">Keine Zusammenfassung verfügbar.</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-[240px] text-sm">
+        <thead>
+          <tr className="text-left text-muted-foreground">
+            <th className="py-1 pr-4 font-medium">Tabelle</th>
+            <th className="py-1 font-medium">Anzahl</th>
+          </tr>
+        </thead>
+        <tbody>
+          {summaryEntries.map(([tableName, count]) => (
+            <tr key={tableName} className="border-t">
+              <td className="py-1 pr-4 capitalize">{tableName.replace(/_/g, ' ')}</td>
+              <td className="py-1 font-mono">{count}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+interface SummaryFetcherProps {
+  item: ImportItem;
+  setItems: Props['setItems'];
+  enabled: boolean;
+}
+
+function useImportSummaryFetcher({ item, setItems, enabled }: SummaryFetcherProps) {
+  const { data, isError, error } = useImportSummary(item.runId, enabled);
+
+  useEffect(() => {
+    if (!enabled || !data) return;
+
+    setItems((arr) =>
+      arr.map((i) => {
+        if (i.id !== item.id) {
+          return i;
+        }
+
+        const finishedAt = data.finished_at ?? undefined;
+        if (!data.finished) {
+          return {
+            ...i,
+            summary: data.summary,
+            finishedAt,
+          };
+        }
+
+        if (
+          i.summaryStatus === 'success' &&
+          i.finishedAt === finishedAt &&
+          shallowEqualSummaries(i.summary, data.summary)
+        ) {
+          return i;
+        }
+
+        return {
+          ...i,
+          summary: data.summary,
+          finishedAt,
+          summaryStatus: 'success',
+          summaryError: undefined,
+        };
+      })
+    );
+  }, [data, enabled, item.id, setItems]);
+
+  useEffect(() => {
+    if (!enabled || !isError) return;
+
+    const message = error instanceof Error ? error.message : 'Unbekannter Fehler';
+    toast.error(message);
+    setItems((arr) =>
+      arr.map((i) =>
+        i.id === item.id
+          ? {
+              ...i,
+              summaryStatus: 'error',
+              summaryError: message,
+            }
+          : i
+      )
+    );
+  }, [enabled, error, isError, item.id, setItems]);
+}
+
+function shallowEqualSummaries(a?: Record<string, number>, b?: Record<string, number>) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((key) => a[key] === b[key]);
 }

--- a/frontend/lib/queries.ts
+++ b/frontend/lib/queries.ts
@@ -5,6 +5,7 @@ import {
   SearchRequest,
   SearchResponse,
   ImportResponse,
+  ImportSummaryResponse,
   CompanyDetailResponse
 } from "./schemas";
 import { sleep } from "./utils";
@@ -65,5 +66,24 @@ export function useTaskPoller(taskId?: string) {
       return data;
     },
     refetchInterval: 2000
+  });
+}
+
+export function useImportSummary(runId?: number, enabled = true) {
+  return useQuery<ImportSummaryResponse>({
+    queryKey: ["import-summary", runId],
+    enabled: Boolean(runId) && enabled,
+    queryFn: async () => {
+      if (!runId) {
+        throw new Error("runId is required to fetch the import summary");
+      }
+      const { data } = await api.get<ImportSummaryResponse>(`/api/imports/${runId}`);
+      return data;
+    },
+    refetchInterval: (query) => {
+      const data = query.state.data as ImportSummaryResponse | undefined;
+      if (!data) return 2000;
+      return data.finished ? false : 2000;
+    }
   });
 }

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -45,6 +45,14 @@ export const ImportResponseSchema = z.object({
 });
 export type ImportResponse = z.infer<typeof ImportResponseSchema>;
 
+export const ImportSummaryResponseSchema = z.object({
+  run_id: z.number(),
+  summary: z.record(z.string(), z.number()).default({}),
+  finished: z.boolean(),
+  finished_at: z.string().nullable().optional()
+});
+export type ImportSummaryResponse = z.infer<typeof ImportSummaryResponseSchema>;
+
 export const EventSchema = z.object({
   event_id: z.number().optional(),
   event_date: z.string().optional(),

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -14,9 +18,24 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
-    }
+      "@/*": [
+        "./*"
+      ]
+    },
+    "esModuleInterop": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- extend import list items to track run IDs, summary state, and populate run_id when the task finishes
- add a React Query hook and schema for polling the import summary endpoint until completion
- render table counts for finished imports, surface summary fetch errors, and initialise new uploads with summary state (plus add a project ESLint config)

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cd3abe588083239f23bbb1a8cc00a5