### PR TITLE
Fix import summary polling interval

### DIFF
--- a/frontend/lib/queries.ts
+++ b/frontend/lib/queries.ts
@@ -80,9 +80,10 @@ export function useImportSummary(runId?: number, enabled = true) {
       const { data } = await api.get<ImportSummaryResponse>(`/api/imports/${runId}`);
       return data;
     },
-    refetchInterval: (query) => {
-      const data = query.state.data as ImportSummaryResponse | undefined;
-      if (!data) return 2000;
+    refetchInterval: (data) => {
+      if (!data) {
+        return 2000;
+      }
       return data.finished ? false : 2000;
     }
   });


### PR DESCRIPTION
## Summary
- update the import summary query to compute the refetch interval from the fetched data instead of the query state
- stop polling once the import run is marked as finished

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cd4be7f74c83238ec618d496a01070