### PR TITLE
Align search request filters with backend schema

### DIFF
--- a/frontend/app/search/page.tsx
+++ b/frontend/app/search/page.tsx
@@ -3,26 +3,42 @@
 import { useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useSearchCompanies } from '@/lib/queries';
+import { SearchRequest } from '@/lib/schemas';
 import FiltersPanel from '@/components/filters-panel';
 import ResultsTable from '@/components/results-table';
 import ExportDialog from '@/components/export-dialog';
 
 export default function SearchPage() {
   const params = useSearchParams();
-  const queryObj = useMemo(() => {
-    const obj: any = {
-      query: params.get('query') ?? undefined,
-      page: Number(params.get('page') ?? '1'),
-      per_page: Number(params.get('per_page') ?? '20'),
-      sort: params.get('sort') ?? undefined,
-      filters: {} as Record<string, string[]>
+  const queryObj = useMemo<SearchRequest>(() => {
+    const toInt = (value: string | null, fallback: number) => {
+      const parsed = Number(value);
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
     };
-    params.forEach((v, k) => {
-      if (!['query', 'page', 'per_page', 'sort'].includes(k)) {
-        obj.filters[k] = obj.filters[k] ? [...obj.filters[k], v] : [v];
+
+    const toNumber = (value: string | null) => {
+      if (value === null) {
+        return undefined;
       }
-    });
-    return obj;
+      const parsed = Number(value);
+      return Number.isFinite(parsed) ? parsed : undefined;
+    };
+
+    return {
+      query: params.get('query') ?? undefined,
+      state: params.get('state') ?? undefined,
+      city: params.get('city') ?? undefined,
+      postal_code: params.get('postal_code') ?? undefined,
+      wz: params.get('wz') ?? undefined,
+      status: params.get('status') ?? undefined,
+      legal_form: params.get('legal_form') ?? undefined,
+      lat: toNumber(params.get('lat')),
+      lng: toNumber(params.get('lng')),
+      radius_km: toNumber(params.get('radius_km')),
+      sort: params.get('sort') ?? undefined,
+      page: toInt(params.get('page'), 1),
+      per_page: toInt(params.get('per_page'), 20)
+    };
   }, [params]);
 
   const { data, isLoading } = useSearchCompanies(queryObj);
@@ -37,7 +53,7 @@ export default function SearchPage() {
           <>
             <ResultsTable data={data.results} selected={selected} onSelectedChange={setSelected} />
             <div className="flex justify-end">
-              <ExportDialog selectedIds={selected} />
+              <ExportDialog selectedIds={selected} request={queryObj} />
             </div>
           </>
         )}

--- a/frontend/components/export-dialog.tsx
+++ b/frontend/components/export-dialog.tsx
@@ -1,25 +1,51 @@
 'use client';
 
 import { useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { useCreateExport } from '@/lib/queries';
+import { SearchRequest } from '@/lib/schemas';
 import { toast } from './toast';
 
-export default function ExportDialog({ selectedIds }: { selectedIds: string[] }) {
+interface ExportDialogProps {
+  selectedIds: string[];
+  request: SearchRequest;
+}
+
+export default function ExportDialog({ selectedIds, request }: ExportDialogProps) {
   const [open, setOpen] = useState(false);
   const [format, setFormat] = useState('csv');
   const [preset, setPreset] = useState('core');
   const createExport = useCreateExport();
-  const params = useSearchParams();
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    const body: any = {
+    const body: Record<string, unknown> = {
       format,
-      preset,
-      ids: selectedIds.length > 0 ? selectedIds : undefined,
-      filters: Object.fromEntries(params.entries())
+      preset
     };
+
+    if (selectedIds.length > 0) {
+      body.ids = selectedIds;
+    }
+
+    const filterKeys: (keyof SearchRequest)[] = [
+      'query',
+      'state',
+      'city',
+      'postal_code',
+      'wz',
+      'status',
+      'legal_form',
+      'lat',
+      'lng',
+      'radius_km'
+    ];
+
+    filterKeys.forEach((key) => {
+      const value = request[key];
+      if (value !== undefined) {
+        (body as any)[key] = value;
+      }
+    });
     try {
       await createExport.mutateAsync(body);
       toast.success('Export gestartet');

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -3,10 +3,18 @@ import { z } from "zod";
 export const SearchRequestSchema = z.object({
   // Free text search query
   query: z.string().optional(),
+  state: z.string().optional(),
+  city: z.string().optional(),
+  postal_code: z.string().optional(),
+  wz: z.string().optional(),
+  status: z.string().optional(),
+  legal_form: z.string().optional(),
+  lat: z.number().optional(),
+  lng: z.number().optional(),
+  radius_km: z.number().optional(),
   page: z.number().int().min(1).default(1),
   per_page: z.number().int().min(1).max(100).default(20),
-  sort: z.string().optional(),
-  filters: z.record(z.string(), z.array(z.string())).optional()
+  sort: z.string().optional()
 });
 export type SearchRequest = z.infer<typeof SearchRequestSchema>;
 


### PR DESCRIPTION
## Summary
- map search page URL parameters to the explicit company search request fields and remove the generic filters payload
- update the frontend search request schema to match the FastAPI contract
- include the normalized search request values in export requests so selected facets such as status are preserved

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cda9827eb0832395d736a8f95c7ead