### PR TITLE
Include status in company search results

### DIFF
--- a/backend/app/schemas/search.py
+++ b/backend/app/schemas/search.py
@@ -22,6 +22,7 @@ class CompanySearchRequest(BaseModel):
 class CompanyItem(BaseModel):
     source_id: str
     name: Optional[str] = None
+    status: Optional[str] = None
 
 
 class FacetBucket(BaseModel):

--- a/backend/app/search.py
+++ b/backend/app/search.py
@@ -72,6 +72,7 @@ def search_companies(client: OpenSearch, query: Dict[str, Any]) -> Dict[str, Any
         {
             "source_id": h.get("_source", {}).get("source_id", ""),
             "name": h.get("_source", {}).get("name"),
+            "status": h.get("_source", {}).get("status"),
         }
         for h in hits.get("hits", [])
     ]

--- a/frontend/components/results-table.tsx
+++ b/frontend/components/results-table.tsx
@@ -3,6 +3,7 @@
 export interface Company {
   source_id: string;
   name: string;
+  status?: string | null;
   [key: string]: any;
 }
 
@@ -39,7 +40,7 @@ export default function ResultsTable({
               onChange={(e) => toggleAll(e.target.checked)}
             />
           </th>
-          <th className="p-2">Name</th>
+          <th className="p-2">Company</th>
         </tr>
       </thead>
       <tbody>
@@ -53,9 +54,22 @@ export default function ResultsTable({
               />
             </td>
             <td className="p-2">
-              <a href={`/company/${item.source_id}`} className="text-primary hover:underline">
-                {item.name}
-              </a>
+              <div className="flex items-center gap-2">
+                <a href={`/company/${item.source_id}`} className="text-primary hover:underline">
+                  {item.name}
+                </a>
+                {item.status && (
+                  <span
+                    className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                      item.status.toLowerCase() === 'active'
+                        ? 'bg-green-100 text-green-800'
+                        : 'bg-gray-200 text-gray-800'
+                    }`}
+                  >
+                    {item.status.toLowerCase() === 'active' ? 'Active' : 'Inactive'}
+                  </span>
+                )}
+              </div>
             </td>
           </tr>
         ))}

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -21,6 +21,7 @@ export type SearchRequest = z.infer<typeof SearchRequestSchema>;
 export const CompanySchema = z.object({
   source_id: z.string(),
   name: z.string(),
+  status: z.string().optional(),
   lat: z.number().optional(),
   lng: z.number().optional(),
   events: z.array(z.string()).optional()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -15,8 +15,20 @@ class DummyOSClient:
             "hits": {
                 "total": {"value": 2},
                 "hits": [
-                    {"_source": {"source_id": "1", "name": "Foo"}},
-                    {"_source": {"source_id": "2", "name": "Bar"}},
+                    {
+                        "_source": {
+                            "source_id": "1",
+                            "name": "Foo",
+                            "status": "active",
+                        }
+                    },
+                    {
+                        "_source": {
+                            "source_id": "2",
+                            "name": "Bar",
+                            "status": "inactive",
+                        }
+                    },
                 ],
             },
             "aggregations": {
@@ -38,8 +50,8 @@ def test_search_companies() -> None:
     data = response.json()
     assert data["total"] == 2
     assert data["results"] == [
-        {"source_id": "1", "name": "Foo"},
-        {"source_id": "2", "name": "Bar"},
+        {"source_id": "1", "name": "Foo", "status": "active"},
+        {"source_id": "2", "name": "Bar", "status": "inactive"},
     ]
     assert data["facets"]["status"][0] == {"value": "active", "count": 2}
     app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- include the company status in search responses on the backend and extend the pydantic schema
- accept the new status field on the frontend schemas and company typings
- render a status badge beside each company name in the search results table and update tests

## Testing
- pytest tests/test_search.py

------
https://chatgpt.com/codex/tasks/task_b_68cdaa7451a88323a9b0bb0f36d13872