### PR TITLE
Add status indicator to company detail page

### DIFF
--- a/frontend/app/company/[source_id]/page.tsx
+++ b/frontend/app/company/[source_id]/page.tsx
@@ -13,9 +13,37 @@ export default function CompanyPage({ params }: { params: { source_id: string } 
 
   const { company, events, persons, industry_codes } = data;
 
+  const normalizedStatus = company.status ? company.status.trim().toLowerCase() : undefined;
+  const statusTranslations: Record<string, { label: string; classes: string }> = {
+    active: { label: 'Aktiv', classes: 'bg-green-100 text-green-800' },
+    terminated: { label: 'Inaktiv', classes: 'bg-gray-200 text-gray-800' },
+    inactive: { label: 'Inaktiv', classes: 'bg-gray-200 text-gray-800' }
+  };
+
+  let statusLabel: string | null = null;
+  let statusClasses = 'rounded-full px-2 py-0.5 text-xs font-semibold ';
+
+  if (company.terminated === true) {
+    statusLabel = 'Inaktiv';
+    statusClasses += 'bg-gray-200 text-gray-800';
+  } else if (normalizedStatus && statusTranslations[normalizedStatus]) {
+    const { label, classes } = statusTranslations[normalizedStatus];
+    statusLabel = label;
+    statusClasses += classes;
+  } else if (normalizedStatus) {
+    statusLabel = normalizedStatus.charAt(0).toUpperCase() + normalizedStatus.slice(1);
+    statusClasses += 'bg-muted text-muted-foreground';
+  } else if (company.terminated === false) {
+    statusLabel = 'Aktiv';
+    statusClasses += 'bg-green-100 text-green-800';
+  }
+
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold">{company.name}</h1>
+      <div className="flex items-center gap-2">
+        <h1 className="text-2xl font-bold">{company.name}</h1>
+        {statusLabel && <span className={statusClasses}>{statusLabel}</span>}
+      </div>
       <div>
         <h2 className="font-medium">Address</h2>
         <Address company={company} />


### PR DESCRIPTION
## Summary
- add a localized status badge next to the company name on the detail page
- derive the badge state from backend status and termination flags while falling back to neutral styling for unknown values

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cdabdd9f34832393f30bbadf137fd3