### PR TITLE
Add stats API endpoint and settings view

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import Connection
 from .config import get_settings
 from .deps import get_db_conn, get_os_client
 from .opensearch_client import ensure_companies_index, get_opensearch
-from .routers import companies, exports, imports, salesforce, search, tasks
+from .routers import companies, exports, imports, salesforce, search, stats, tasks
 
 app = FastAPI(title="BVMW Companies API")
 
@@ -26,6 +26,7 @@ app.include_router(companies.router)
 app.include_router(imports.router)
 app.include_router(exports.router)
 app.include_router(salesforce.router)
+app.include_router(stats.router)
 app.include_router(tasks.router)
 
 

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy import MetaData, func, select
+from sqlalchemy.engine import Connection
+
+from ..deps import get_db_conn
+from ..schemas.stats import TableCount, TableCountsResponse
+
+router = APIRouter(prefix="/api/stats", tags=["stats"])
+
+
+@router.get("/table-counts", response_model=TableCountsResponse)
+def get_table_counts(db: Connection = Depends(get_db_conn)) -> TableCountsResponse:
+    metadata = MetaData()
+    reflect_kwargs: dict[str, object] = {}
+    if db.dialect.name == "postgresql":
+        reflect_kwargs["schema"] = "public"
+    metadata.reflect(bind=db, **reflect_kwargs)
+
+    counts = []
+    for table in metadata.sorted_tables:
+        count_stmt = select(func.count()).select_from(table)
+        count = db.execute(count_stmt).scalar_one()
+        counts.append(TableCount(table=table.name, rows=count))
+
+    return TableCountsResponse(counts=counts)

--- a/backend/app/schemas/stats.py
+++ b/backend/app/schemas/stats.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class TableCount(BaseModel):
+    table: str
+    rows: int
+
+
+class TableCountsResponse(BaseModel):
+    counts: list[TableCount]

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <nav className="flex flex-col gap-2">
               <Link href="/search" className="hover:underline">Search</Link>
               <Link href="/admin/import" className="hover:underline">Import</Link>
-              <Link href="#" className="hover:underline">Settings</Link>
+              <Link href="/settings" className="hover:underline">Settings</Link>
             </nav>
           </aside>
           <div className="flex-1 flex flex-col">

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useTableCounts } from "@/lib/queries";
+
+export default function SettingsPage() {
+  const { data, isLoading, isError, error, refetch } = useTableCounts();
+
+  return (
+    <div className="space-y-6">
+      <section className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Settings</h1>
+          <p className="text-sm text-muted-foreground">
+            Übersicht der verfügbaren Datenbanktabellen und ihrer Datensätze.
+          </p>
+        </div>
+        {isLoading && <p>Loading table statistics...</p>}
+        {isError && (
+          <div className="space-y-2">
+            <p className="text-red-600">
+              {error instanceof Error ? error.message : "Failed to load table statistics."}
+            </p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="px-3 py-1 rounded border hover:bg-muted"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+        {!isLoading && !isError && (
+          <div className="overflow-x-auto">
+            <table className="min-w-full border border-border text-sm">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="px-3 py-2 text-left">Table</th>
+                  <th className="px-3 py-2 text-right">Rows</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data?.counts.map((item) => (
+                  <tr key={item.table} className="border-t border-border">
+                    <td className="px-3 py-2 font-medium">{item.table}</td>
+                    <td className="px-3 py-2 text-right">
+                      {item.rows.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+                {data && data.counts.length === 0 && (
+                  <tr>
+                    <td colSpan={2} className="px-3 py-4 text-center text-muted-foreground">
+                      No tables found.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/lib/queries.ts
+++ b/frontend/lib/queries.ts
@@ -6,7 +6,8 @@ import {
   SearchResponse,
   ImportResponse,
   ImportSummaryResponse,
-  CompanyDetailResponse
+  CompanyDetailResponse,
+  TableCountsResponse
 } from "./schemas";
 import { sleep } from "./utils";
 
@@ -85,6 +86,16 @@ export function useImportSummary(runId?: number, enabled = true) {
         return 2000;
       }
       return data.finished ? false : 2000;
+    }
+  });
+}
+
+export function useTableCounts() {
+  return useQuery<TableCountsResponse>({
+    queryKey: ["table-counts"],
+    queryFn: async () => {
+      const { data } = await api.get<TableCountsResponse>("/api/stats/table-counts");
+      return data;
     }
   });
 }

--- a/frontend/lib/schemas.ts
+++ b/frontend/lib/schemas.ts
@@ -114,3 +114,14 @@ export const CompanyDetailResponseSchema = z.object({
   industry_codes: z.array(IndustryCodeSchema)
 });
 export type CompanyDetailResponse = z.infer<typeof CompanyDetailResponseSchema>;
+
+export const TableCountSchema = z.object({
+  table: z.string(),
+  rows: z.number()
+});
+export type TableCount = z.infer<typeof TableCountSchema>;
+
+export const TableCountsResponseSchema = z.object({
+  counts: z.array(TableCountSchema)
+});
+export type TableCountsResponse = z.infer<typeof TableCountsResponseSchema>;

--- a/tests/test_stats_router.py
+++ b/tests/test_stats_router.py
@@ -1,0 +1,44 @@
+import pytest
+
+pytest.importorskip("httpx")
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import StaticPool
+
+from backend.app.deps import get_db_conn
+from backend.app.main import app
+
+
+def test_table_counts_endpoint_returns_counts() -> None:
+    engine = create_engine(
+        "sqlite://",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE companies (id INTEGER, name TEXT)"))
+        conn.execute(text("CREATE TABLE events (id INTEGER, description TEXT)"))
+        conn.execute(text("INSERT INTO companies (id, name) VALUES (1, 'Acme'), (2, 'Globex')"))
+        conn.execute(text("INSERT INTO events (id, description) VALUES (1, 'Launch')"))
+
+    def override_get_db_conn():
+        with engine.begin() as conn:
+            yield conn
+
+    app.dependency_overrides[get_db_conn] = override_get_db_conn
+
+    client = TestClient(app)
+    response = client.get("/api/stats/table-counts")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "counts": [
+            {"table": "companies", "rows": 2},
+            {"table": "events", "rows": 1},
+        ]
+    }
+
+    app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- add backend schemas and router to expose table count statistics
- register the stats endpoint and cover it with unit tests
- extend the frontend with table count schemas, query hook, navigation, and settings page

## Testing
- pytest
- npm --prefix frontend run lint

------
https://chatgpt.com/codex/tasks/task_b_68cdb0532a948323a0ad2fa60a12274d